### PR TITLE
feat(factory): add deterministic daily development control plane

### DIFF
--- a/.github/workflows/daily-factory-control-plane.yml
+++ b/.github/workflows/daily-factory-control-plane.yml
@@ -6,10 +6,11 @@ on:
     - cron: "0 7 * * *"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
-  group: daily-factory-control-plane
+  group: daily-factory-control-plane-${{ github.repository_id }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -17,15 +18,40 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+      - name: Compute Europe/Moscow production date
+        id: moscow-date
+        run: >-
+          python3 -c 'from datetime import datetime; from zoneinfo import ZoneInfo;
+          print("date=" + datetime.now(ZoneInfo("Europe/Moscow")).date().isoformat())'
+          >> "$GITHUB_OUTPUT"
+      - name: Restore exact immutable daily claim
+        id: daily-claim-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: factory/artifacts/run-history/${{ steps.moscow-date.outputs.date }}.json
+          key: factory-daily-claim-${{ github.repository_id }}-${{ github.ref }}-${{ steps.moscow-date.outputs.date }}
       - name: Run deterministic FACTORY-001A control plane
-        run: python3 -m factory.daily_run --dry-run
+        env:
+          FACTORY_GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 -m factory.daily_run --dry-run
+          --date "${{ steps.moscow-date.outputs.date }}"
+          --owner-id "${{ github.run_id }}:${{ github.run_attempt }}"
+      - name: Save immutable daily claim as optional transport
+        if: steps.daily-claim-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: factory/artifacts/run-history/${{ steps.moscow-date.outputs.date }}.json
+          key: factory-daily-claim-${{ github.repository_id }}-${{ github.ref }}-${{ steps.moscow-date.outputs.date }}
       - name: Publish Owner Report and execution plan
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: factory-owner-report
           path: factory/artifacts/

--- a/.github/workflows/daily-factory-control-plane.yml
+++ b/.github/workflows/daily-factory-control-plane.yml
@@ -1,0 +1,33 @@
+name: daily-factory-control-plane
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-factory-control-plane
+  cancel-in-progress: false
+
+jobs:
+  deterministic-dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run deterministic FACTORY-001A control plane
+        run: python3 -m factory.daily_run --dry-run
+      - name: Publish Owner Report and execution plan
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: factory-owner-report
+          path: factory/artifacts/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -12,8 +12,10 @@ jobs:
   factory-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ signals_history.json
 
 # Private local Telegram Desktop exports
 /private/telegram_exports/
+
+# Deterministic FACTORY-001A run artifacts
+/factory/artifacts/

--- a/docs/owner/CURRENT_STATE.md
+++ b/docs/owner/CURRENT_STATE.md
@@ -3,9 +3,12 @@
 - Active core freeze: `FROZEN_CORE_V12`.
 - Historical baseline: `FROZEN_CORE_V11`, preserved unchanged.
 - PM-DEC-007 semantics: unchanged. V1 is historical; V2 is the active operational bundle.
-- FACTORY-001A: implemented; focused local gates and self-check pass. Authoritative full Ubuntu CI is pending.
+- FACTORY-001A: `REVIEW`; the Development Factory Baseline is awaiting fresh governed Ubuntu CI, which is authoritative for the full release gate.
 - Daily schedule: 10:00 Europe/Moscow (`07:00 UTC`).
-- Current registry result: `NEEDS_OWNER` because FACTORY-001B is not approved.
+- Current authority: read, validate, select one approved task, plan, and report only.
+- Next: Product Master Spec plus a Living Roadmap.
+- FACTORY-001B: deferred and not part of the current stage.
 - AI usage in scheduled runs: `0`.
-- Local Windows full suite: environment-limited by unavailable dependencies and POSIX/SQLite behavior; not counted as PASS.
+- Local Windows full `self_check`: not authoritative because checkout EOL representation can affect raw evidence bytes; do not count it as PASS.
+- Future security: add strong external release trust/signing only before authority grows to autonomous repository writes, Paper, Limited Live, or capital-bearing operation.
 - Paper and Live: blocked.

--- a/docs/owner/CURRENT_STATE.md
+++ b/docs/owner/CURRENT_STATE.md
@@ -1,0 +1,11 @@
+# Current State
+
+- Active core freeze: `FROZEN_CORE_V12`.
+- Historical baseline: `FROZEN_CORE_V11`, preserved unchanged.
+- PM-DEC-007 semantics: unchanged. V1 is historical; V2 is the active operational bundle.
+- FACTORY-001A: implemented; focused local gates and self-check pass. Authoritative full Ubuntu CI is pending.
+- Daily schedule: 10:00 Europe/Moscow (`07:00 UTC`).
+- Current registry result: `NEEDS_OWNER` because FACTORY-001B is not approved.
+- AI usage in scheduled runs: `0`.
+- Local Windows full suite: environment-limited by unavailable dependencies and POSIX/SQLite behavior; not counted as PASS.
+- Paper and Live: blocked.

--- a/docs/owner/DECISION_LOG.md
+++ b/docs/owner/DECISION_LOG.md
@@ -26,3 +26,12 @@
 - Resolution: PM-DEC-007 V1 is preserved as historical. PM-DEC-007 V2 is the active operational bundle and verifies active core V12.
 - Reason: the approved agent architecture added mandatory `game_ux_designer` and `pro_trader_ux` roles to core V12.
 - PM semantics and authority remain unchanged. Paper, Live, agents, commits, pushes, pull requests, and merge remain blocked.
+
+## FACTORY-DEC-004 — FACTORY-001A release-blocking hardening only
+
+- Date: 2026-08-11
+- Status: OWNER_APPROVED
+- Decision: correct only the five reviewed FACTORY-001A release blockers: lock ownership, durable daily history, `READY` authority, production trust-boundary injection, and workflow action pinning.
+- Release state: FACTORY-001A remains `REVIEW` until the required independent reviews and release verification pass.
+- Explicit exclusions: this decision grants no FACTORY-001B, Product Master Spec, coding-agent execution, trading-code, credential, Paper, Live, capital, commit, push, pull-request, merge, or risk-policy authority.
+- Frozen evidence: no frozen manifest is changed by this decision.

--- a/docs/owner/DECISION_LOG.md
+++ b/docs/owner/DECISION_LOG.md
@@ -1,0 +1,28 @@
+# Owner Decision Log
+
+## FACTORY-DEC-001 — Controlled core re-freeze
+
+- Date: 2026-08-11
+- Status: APPROVED
+- Reason: UI product-development agents are now mandatory parts of the agent factory.
+- Decision: `game_ux_designer` and `pro_trader_ux` are required, read-only agents with high reasoning effort.
+- Freeze: `FROZEN_CORE_V11` remains an immutable historical baseline. `FROZEN_CORE_V12` is the active core freeze.
+- Authority unchanged: this decision grants no Paper, Live, credential, exchange, order, or financial authority.
+
+## FACTORY-DEC-002 — FACTORY-001A authority boundary
+
+- Date: 2026-08-11
+- Status: APPROVED
+- Decision: the daily runner may validate, select, plan, and report one `READY` task.
+- Limit: it cannot invoke Codex or another writer, change product scope, commit, push, create a pull request, merge, or grant trading authority.
+- Next gate: FACTORY-001B requires a separate Owner decision.
+
+## FACTORY-DEC-003 — Frozen parent compatibility conflict
+
+- Date: 2026-08-11
+- Status: RESOLVED / OWNER_APPROVED
+- Evidence: V12 passes `10/10`, while frozen PM-DEC-007 V1 tests require V11 to pass `10/10` with the old `scripts/self_check.py` hash.
+- Constraint: one file cannot match both the V11 and V12 hash.
+- Resolution: PM-DEC-007 V1 is preserved as historical. PM-DEC-007 V2 is the active operational bundle and verifies active core V12.
+- Reason: the approved agent architecture added mandatory `game_ux_designer` and `pro_trader_ux` roles to core V12.
+- PM semantics and authority remain unchanged. Paper, Live, agents, commits, pushes, pull requests, and merge remain blocked.

--- a/docs/owner/GLOSSARY.md
+++ b/docs/owner/GLOSSARY.md
@@ -1,0 +1,10 @@
+# Glossary
+
+- **Epic:** Owner-approved product outcome that may be decomposed without changing its scope.
+- **Task:** Bounded work item. Only `READY` is selectable.
+- **Owner Decision:** Explicit approval or unresolved gate for scope or authority.
+- **Run:** One deterministic daily planning attempt.
+- **Preflight:** Fail-closed checks before selection.
+- **Owner Report:** Human-readable daily result and next action.
+- **Frozen evidence:** Versioned files whose canonical hashes must match.
+- **FACTORY-001B:** Proposed future coding-agent execution; currently unauthorized.

--- a/docs/owner/OWNER_BRIEF.md
+++ b/docs/owner/OWNER_BRIEF.md
@@ -1,0 +1,7 @@
+# Owner Brief
+
+FACTORY-001A is a daily planning control plane. It validates the registry, chooses at most one safe `READY` task, and writes a plan plus Owner Report.
+
+It does not call Codex, write product code, commit, push, open pull requests, merge, trade, or handle credentials.
+
+The Owner still decides product scope, architecture authority, governance, markets, exchanges, Paper, Live, and financial authority.

--- a/docs/owner/ROADMAP.md
+++ b/docs/owner/ROADMAP.md
@@ -1,0 +1,23 @@
+# Roadmap
+
+## CURRENT
+
+- Controlled V12 core freeze.
+- Historical PM V1 plus active operational PM V2 freeze.
+- Deterministic registry, preflight, task selection, plan, Owner Report, and daily scheduler.
+
+## NEXT
+
+- Run the authoritative full repository gate in Ubuntu CI.
+- Owner review of FACTORY-001A evidence.
+- Decide whether FACTORY-001B may be specified.
+
+## FUTURE
+
+- Bounded coding-agent execution only after a separate approved contract.
+- Optional Owner UI over the same versioned registry.
+
+## BLOCKED
+
+- Automatic Codex invocation, writer execution, commit, push, pull request, and merge.
+- Credentials, Telegram/Bitget APIs, Paper, Live, orders, positions, and fills.

--- a/docs/owner/ROADMAP.md
+++ b/docs/owner/ROADMAP.md
@@ -1,20 +1,23 @@
 # Roadmap
 
-## CURRENT
+## CURRENT — Development Factory Baseline
 
 - Controlled V12 core freeze.
 - Historical PM V1 plus active operational PM V2 freeze.
 - Deterministic registry, preflight, task selection, plan, Owner Report, and daily scheduler.
+- FACTORY-001A remains `REVIEW`, awaiting fresh authoritative governed Ubuntu CI.
 
-## NEXT
+## NEXT — Product Master Spec + Living Roadmap
 
-- Run the authoritative full repository gate in Ubuntu CI.
-- Owner review of FACTORY-001A evidence.
-- Decide whether FACTORY-001B may be specified.
+- Define the Product Master Spec and maintain the Living Roadmap after the baseline clears fresh Ubuntu CI.
 
-## FUTURE
+## FUTURE SECURITY
 
-- Bounded coding-agent execution only after a separate approved contract.
+- Add strong external release trust/signing only before authority grows to autonomous repository writes, Paper, Limited Live, or capital-bearing operation.
+
+## DEFERRED
+
+- FACTORY-001B and bounded coding-agent execution are not current work and require a separate approved contract.
 - Optional Owner UI over the same versioned registry.
 
 ## BLOCKED

--- a/docs/owner/SYSTEM_MAP.md
+++ b/docs/owner/SYSTEM_MAP.md
@@ -1,0 +1,18 @@
+# System Map
+
+```text
+GitHub schedule/manual trigger
+        |
+        v
+factory.daily_run --dry-run
+        |
+        +--> registry validation
+        +--> frozen/governance verification
+        +--> repository and budget preflight
+        +--> deterministic READY selection
+        |
+        v
+execution plan + Owner Report
+```
+
+There is no connection to Codex, Telegram, Bitget, orders, positions, Paper, Live, commits, pushes, pull requests, or merge.

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic FACTORY-001A development control plane."""
+
+from .models import RUN_STATUSES, TASK_STATUSES
+
+__all__ = ["RUN_STATUSES", "TASK_STATUSES"]

--- a/factory/configuration.py
+++ b/factory/configuration.py
@@ -1,0 +1,105 @@
+"""Strict loader for immutable FACTORY-001A daily limits."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from .models import DailyConfig, GovernanceEvidence
+
+
+class ConfigurationError(ValueError):
+    """Raised for unsafe or ambiguous daily-run configuration."""
+
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _sha(value: object, field: str) -> str:
+    if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
+        raise ConfigurationError(f"{field} must be a lowercase SHA-256")
+    return value
+
+
+def _relative(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ConfigurationError(f"{field} must be a non-empty path")
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ConfigurationError(f"{field} must remain repository-relative")
+    return value.replace("\\", "/")
+
+
+def load_daily_config(path: Path) -> DailyConfig:
+    try:
+        with path.open("rb") as handle:
+            raw = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigurationError(f"cannot load daily config {path}: {exc}") from exc
+    required_exact = {
+        "schema_version": 1,
+        "timezone": "Europe/Moscow",
+        "max_tasks_per_day": 1,
+        "max_parallel_writers": 1,
+        "max_correction_loops": 2,
+        "max_run_time_minutes": 90,
+        "auto_merge": False,
+        "auto_product_approval": False,
+        "paper_authority": False,
+        "live_authority": False,
+    }
+    for key, expected in required_exact.items():
+        if raw.get(key) != expected:
+            raise ConfigurationError(f"{key} must remain {expected!r}")
+    repository = raw.get("repository", {})
+    if repository.get("allow_dirty") is not False:
+        raise ConfigurationError("repository.allow_dirty must remain false")
+    prefixes = repository.get("allowed_dirty_prefixes", [])
+    if not isinstance(prefixes, list) or any(not isinstance(item, str) or not item for item in prefixes):
+        raise ConfigurationError("allowed_dirty_prefixes must be non-empty strings")
+    integrity = raw.get("integrity", {})
+    if integrity.get("canonicalization") != "UTF8_LF_TEXT_RAW_BINARY_V1":
+        raise ConfigurationError("unsupported integrity canonicalization")
+    governance_raw = integrity.get("governance", [])
+    if not isinstance(governance_raw, list) or not governance_raw:
+        raise ConfigurationError("at least one governance hash is required")
+    governance = tuple(
+        GovernanceEvidence(
+            path=_relative(item.get("path"), f"integrity.governance[{index}].path"),
+            sha256=_sha(item.get("sha256"), f"integrity.governance[{index}].sha256"),
+        )
+        for index, item in enumerate(governance_raw)
+    )
+    routing_raw = raw.get("routing", {})
+    routing: dict[str, tuple[str, ...]] = {}
+    for level in ("high", "medium", "low"):
+        values = routing_raw.get(level)
+        if not isinstance(values, list) or any(not isinstance(item, str) or not item for item in values):
+            raise ConfigurationError(f"routing.{level} must be a list of non-empty strings")
+        routing[level] = tuple(values)
+    return DailyConfig(
+        schema_version=1,
+        timezone="Europe/Moscow",
+        max_tasks_per_day=1,
+        max_parallel_writers=1,
+        max_correction_loops=2,
+        max_run_time_minutes=90,
+        auto_merge=False,
+        auto_product_approval=False,
+        paper_authority=False,
+        live_authority=False,
+        allow_dirty=False,
+        allowed_dirty_prefixes=tuple(prefix.replace("\\", "/") for prefix in prefixes),
+        canonicalization="UTF8_LF_TEXT_RAW_BINARY_V1",
+        active_core_manifest=_relative(integrity.get("active_core_manifest"), "active_core_manifest"),
+        active_core_manifest_sha256=_sha(
+            integrity.get("active_core_manifest_sha256"), "active_core_manifest_sha256"
+        ),
+        pm_dec_007_manifest=_relative(integrity.get("pm_dec_007_manifest"), "pm_dec_007_manifest"),
+        pm_dec_007_manifest_sha256=_sha(
+            integrity.get("pm_dec_007_manifest_sha256"), "pm_dec_007_manifest_sha256"
+        ),
+        governance=governance,
+        routing=routing,
+    )

--- a/factory/configuration.py
+++ b/factory/configuration.py
@@ -56,8 +56,10 @@ def load_daily_config(path: Path) -> DailyConfig:
     if repository.get("allow_dirty") is not False:
         raise ConfigurationError("repository.allow_dirty must remain false")
     prefixes = repository.get("allowed_dirty_prefixes", [])
-    if not isinstance(prefixes, list) or any(not isinstance(item, str) or not item for item in prefixes):
-        raise ConfigurationError("allowed_dirty_prefixes must be non-empty strings")
+    if prefixes != ["factory/artifacts/"]:
+        raise ConfigurationError(
+            'repository.allowed_dirty_prefixes must remain exactly ["factory/artifacts/"]'
+        )
     integrity = raw.get("integrity", {})
     if integrity.get("canonicalization") != "UTF8_LF_TEXT_RAW_BINARY_V1":
         raise ConfigurationError("unsupported integrity canonicalization")

--- a/factory/daily_run.py
+++ b/factory/daily_run.py
@@ -1,0 +1,161 @@
+"""CLI entry point for the deterministic FACTORY-001A daily dry-run."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from contextlib import contextmanager
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterator
+from zoneinfo import ZoneInfo
+
+from .configuration import ConfigurationError, load_daily_config
+from .integrity import safe_repo_path
+from .models import RepositoryState, RunOutcome
+from .planning import build_execution_plan, render_owner_report, write_plan, write_report
+from .preflight import run_preflight
+from .registry import RegistryError, load_registry
+from .state_machine import DailyRunStateMachine
+
+
+DEFAULT_REGISTRY = "factory/registry.toml"
+DEFAULT_CONFIG = "factory/daily_run.toml"
+DEFAULT_OUTPUT = "factory/artifacts"
+
+
+@contextmanager
+def exclusive_run_lock(root: Path, output_dir: str) -> Iterator[None]:
+    directory = safe_repo_path(root, output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    lock_path = directory / ".daily-run.lock"
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.write(descriptor, b"FACTORY-001A\n")
+        os.close(descriptor)
+        descriptor = None
+        yield
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _date(value: str | None, timezone: str) -> date:
+    if value is None:
+        return datetime.now(ZoneInfo(timezone)).date()
+    return date.fromisoformat(value)
+
+
+def execute_daily_run(
+    root: Path,
+    *,
+    registry_path: str = DEFAULT_REGISTRY,
+    config_path: str = DEFAULT_CONFIG,
+    output_dir: str = DEFAULT_OUTPUT,
+    run_date: date | None = None,
+    repository_state: RepositoryState | None = None,
+    integrity_issues: tuple[str, ...] | None = None,
+) -> RunOutcome:
+    root = root.resolve()
+    config = load_daily_config(safe_repo_path(root, config_path))
+    registry = load_registry(safe_repo_path(root, registry_path))
+    effective_date = run_date or datetime.now(ZoneInfo(config.timezone)).date()
+    machine = DailyRunStateMachine()
+    machine.transition("PREFLIGHT")
+    preflight = run_preflight(
+        registry,
+        config,
+        root,
+        effective_date,
+        repository_state=repository_state,
+        integrity_issues=integrity_issues,
+    )
+    plan = None
+    plan_path = ""
+    report_path = ""
+    if preflight.status == "TASK_SELECTED":
+        machine.transition("TASK_SELECTED")
+        assert preflight.selected_task is not None
+        plan = build_execution_plan(
+            root,
+            registry,
+            config,
+            preflight.selected_task,
+            effective_date.isoformat(),
+        )
+        written_plan = write_plan(root, output_dir, effective_date.isoformat(), plan)
+        plan_path = written_plan.relative_to(root).as_posix()
+        machine.transition("PLAN_CREATED")
+        target_status = "REPORT_CREATED"
+        report = render_owner_report(
+            registry, config, preflight, effective_date.isoformat(), target_status, plan
+        )
+        written_report = write_report(root, output_dir, effective_date.isoformat(), report)
+        report_path = written_report.relative_to(root).as_posix()
+        machine.transition(target_status)
+    else:
+        target_status = preflight.status
+        report = render_owner_report(
+            registry, config, preflight, effective_date.isoformat(), target_status, None
+        )
+        written_report = write_report(root, output_dir, effective_date.isoformat(), report)
+        report_path = written_report.relative_to(root).as_posix()
+        machine.transition(target_status)
+    return RunOutcome(
+        date=effective_date.isoformat(),
+        status=machine.status,
+        selected_task_id=preflight.selected_task.id if preflight.selected_task else "",
+        plan_path=plan_path,
+        report_path=report_path,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="required: never invoke a coding agent")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--registry", default=DEFAULT_REGISTRY)
+    parser.add_argument("--config", default=DEFAULT_CONFIG)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT)
+    parser.add_argument("--date", help="deterministic Moscow date in YYYY-MM-DD")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.dry_run:
+        print("FACTORY-001A refuses to run without --dry-run", file=sys.stderr)
+        return 2
+    root = Path(args.root).resolve()
+    try:
+        config = load_daily_config(safe_repo_path(root, args.config))
+        run_date = _date(args.date, config.timezone)
+        with exclusive_run_lock(root, args.output_dir):
+            outcome = execute_daily_run(
+                root,
+                registry_path=args.registry,
+                config_path=args.config,
+                output_dir=args.output_dir,
+                run_date=run_date,
+            )
+    except FileExistsError:
+        print("FACTORY-001A BLOCKED: another daily-run lock exists", file=sys.stderr)
+        return 3
+    except (ConfigurationError, RegistryError, OSError, ValueError) as exc:
+        print(f"FACTORY-001A FAILED: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"FACTORY-001A {outcome.status}: task={outcome.selected_task_id or 'NONE'} "
+        f"report={outcome.report_path} ai_usage=0"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/factory/daily_run.py
+++ b/factory/daily_run.py
@@ -3,20 +3,28 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import os
 import sys
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from datetime import date, datetime
 from pathlib import Path
 from typing import Iterator
 from zoneinfo import ZoneInfo
 
 from .configuration import ConfigurationError, load_daily_config
-from .integrity import safe_repo_path
-from .models import RepositoryState, RunOutcome
+from .github_history import (
+    GitHubHistoryError,
+    github_actions_enabled,
+    verify_github_daily_history,
+)
+from .integrity import safe_repo_path, verify_integrity
+from .models import DailyConfig, Registry, RepositoryState, RunOutcome
 from .planning import build_execution_plan, render_owner_report, write_plan, write_report
-from .preflight import run_preflight
+from .preflight import _evaluate_preflight
 from .registry import RegistryError, load_registry
+from .repository import probe_repository
+from .run_history import RunHistoryError, claim_daily_run
 from .state_machine import DailyRunStateMachine
 
 
@@ -25,25 +33,106 @@ DEFAULT_CONFIG = "factory/daily_run.toml"
 DEFAULT_OUTPUT = "factory/artifacts"
 
 
+class RunLockError(OSError):
+    """Raised when platform lock ownership is unsupported or ambiguous."""
+
+
+def _contention_error(exc: OSError) -> FileExistsError | None:
+    contention_codes = {errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK}
+    if exc.errno in contention_codes or getattr(exc, "winerror", None) in {33, 36}:
+        return FileExistsError(errno.EEXIST, "another daily-run lock holder exists")
+    return None
+
+
+def _ensure_windows_lock_byte(descriptor: int) -> None:
+    if os.fstat(descriptor).st_size == 0:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.write(descriptor, b"\0") != 1:
+            raise RunLockError("could not initialize persistent Windows lock byte")
+        os.fsync(descriptor)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+
+
+def _acquire_platform_lock(
+    descriptor: int,
+    *,
+    platform: str | None = None,
+    posix_module=None,
+    windows_module=None,
+) -> None:
+    selected = platform or os.name
+    try:
+        if selected == "posix":
+            if posix_module is None:
+                import fcntl as posix_module
+
+            posix_module.flock(descriptor, posix_module.LOCK_EX | posix_module.LOCK_NB)
+            return
+        if selected == "nt":
+            if windows_module is None:
+                import msvcrt as windows_module
+
+            _ensure_windows_lock_byte(descriptor)
+            windows_module.locking(descriptor, windows_module.LK_NBLCK, 1)
+            return
+    except OSError as exc:
+        contention = _contention_error(exc)
+        if contention is not None:
+            raise contention from exc
+        raise RunLockError(f"ambiguous {selected} daily-run lock acquisition") from exc
+    raise RunLockError(f"unsupported daily-run lock platform: {selected}")
+
+
+def _release_platform_lock(
+    descriptor: int,
+    *,
+    platform: str | None = None,
+    posix_module=None,
+    windows_module=None,
+) -> None:
+    selected = platform or os.name
+    try:
+        if selected == "posix":
+            if posix_module is None:
+                import fcntl as posix_module
+
+            posix_module.flock(descriptor, posix_module.LOCK_UN)
+            return
+        if selected == "nt":
+            if windows_module is None:
+                import msvcrt as windows_module
+
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            windows_module.locking(descriptor, windows_module.LK_UNLCK, 1)
+            return
+    except OSError as exc:
+        raise RunLockError(f"ambiguous {selected} daily-run lock release") from exc
+    raise RunLockError(f"unsupported daily-run lock platform: {selected}")
+
+
 @contextmanager
-def exclusive_run_lock(root: Path, output_dir: str) -> Iterator[None]:
+def _exclusive_run_lock_for_test(root: Path, output_dir: str) -> Iterator[None]:
     directory = safe_repo_path(root, output_dir)
     directory.mkdir(parents=True, exist_ok=True)
     lock_path = directory / ".daily-run.lock"
-    descriptor: int | None = None
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    acquired = False
     try:
-        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        os.write(descriptor, b"FACTORY-001A\n")
-        os.close(descriptor)
-        descriptor = None
+        _acquire_platform_lock(descriptor)
+        acquired = True
         yield
     finally:
-        if descriptor is not None:
-            os.close(descriptor)
         try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
+            if acquired:
+                _release_platform_lock(descriptor)
+        finally:
+            os.close(descriptor)
+
+
+def exclusive_run_lock(root: Path) -> AbstractContextManager[None]:
+    """Return the canonical production lock context."""
+
+    return _exclusive_run_lock_for_test(root, DEFAULT_OUTPUT)
 
 
 def _date(value: str | None, timezone: str) -> date:
@@ -55,20 +144,71 @@ def _date(value: str | None, timezone: str) -> date:
 def execute_daily_run(
     root: Path,
     *,
+    owner_id: str,
+    run_date: date | None = None,
+) -> RunOutcome:
+    """Execute production planning from canonical repository inputs and probes."""
+
+    root = root.resolve()
+    effective_date = run_date or datetime.now(ZoneInfo("Europe/Moscow")).date()
+    with exclusive_run_lock(root):
+        config = load_daily_config(safe_repo_path(root, DEFAULT_CONFIG))
+        registry = load_registry(safe_repo_path(root, DEFAULT_REGISTRY), root=root)
+        if github_actions_enabled():
+            verify_github_daily_history(effective_date)
+        claim_daily_run(root, effective_date, owner_id)
+        repository_state = probe_repository(root)
+        integrity_issues = verify_integrity(root, config)
+        return _execute_daily_run_core(
+            root,
+            registry=registry,
+            config=config,
+            output_dir=DEFAULT_OUTPUT,
+            effective_date=effective_date,
+            repository_state=repository_state,
+            integrity_issues=integrity_issues,
+        )
+
+
+def _execute_daily_run_for_test(
+    root: Path,
+    *,
     registry_path: str = DEFAULT_REGISTRY,
     config_path: str = DEFAULT_CONFIG,
     output_dir: str = DEFAULT_OUTPUT,
-    run_date: date | None = None,
-    repository_state: RepositoryState | None = None,
-    integrity_issues: tuple[str, ...] | None = None,
+    run_date: date,
+    repository_state: RepositoryState,
+    integrity_issues: tuple[str, ...],
 ) -> RunOutcome:
+    """Private deterministic test boundary; never used by the CLI."""
+
     root = root.resolve()
     config = load_daily_config(safe_repo_path(root, config_path))
-    registry = load_registry(safe_repo_path(root, registry_path))
-    effective_date = run_date or datetime.now(ZoneInfo(config.timezone)).date()
+    registry = load_registry(safe_repo_path(root, registry_path), root=root)
+    return _execute_daily_run_core(
+        root,
+        registry=registry,
+        config=config,
+        output_dir=output_dir,
+        effective_date=run_date,
+        repository_state=repository_state,
+        integrity_issues=integrity_issues,
+    )
+
+
+def _execute_daily_run_core(
+    root: Path,
+    *,
+    registry: Registry,
+    config: DailyConfig,
+    output_dir: str,
+    effective_date: date,
+    repository_state: RepositoryState,
+    integrity_issues: tuple[str, ...],
+) -> RunOutcome:
     machine = DailyRunStateMachine()
     machine.transition("PREFLIGHT")
-    preflight = run_preflight(
+    preflight = _evaluate_preflight(
         registry,
         config,
         root,
@@ -120,10 +260,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="required: never invoke a coding agent")
     parser.add_argument("--root", default=".", help="repository root")
-    parser.add_argument("--registry", default=DEFAULT_REGISTRY)
-    parser.add_argument("--config", default=DEFAULT_CONFIG)
-    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT)
     parser.add_argument("--date", help="deterministic Moscow date in YYYY-MM-DD")
+    parser.add_argument("--owner-id", required=True, help="stable invocation owner ID")
     return parser
 
 
@@ -134,20 +272,23 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     root = Path(args.root).resolve()
     try:
-        config = load_daily_config(safe_repo_path(root, args.config))
-        run_date = _date(args.date, config.timezone)
-        with exclusive_run_lock(root, args.output_dir):
-            outcome = execute_daily_run(
-                root,
-                registry_path=args.registry,
-                config_path=args.config,
-                output_dir=args.output_dir,
-                run_date=run_date,
-            )
+        run_date = _date(args.date, "Europe/Moscow")
+        outcome = execute_daily_run(
+            root,
+            run_date=run_date,
+            owner_id=args.owner_id,
+        )
     except FileExistsError:
         print("FACTORY-001A BLOCKED: another daily-run lock exists", file=sys.stderr)
         return 3
-    except (ConfigurationError, RegistryError, OSError, ValueError) as exc:
+    except (
+        ConfigurationError,
+        GitHubHistoryError,
+        RegistryError,
+        RunHistoryError,
+        OSError,
+        ValueError,
+    ) as exc:
         print(f"FACTORY-001A FAILED: {exc}", file=sys.stderr)
         return 1
     print(

--- a/factory/daily_run.toml
+++ b/factory/daily_run.toml
@@ -1,0 +1,34 @@
+schema_version = 1
+timezone = "Europe/Moscow"
+max_tasks_per_day = 1
+max_parallel_writers = 1
+max_correction_loops = 2
+max_run_time_minutes = 90
+auto_merge = false
+auto_product_approval = false
+paper_authority = false
+live_authority = false
+
+[repository]
+allow_dirty = false
+allowed_dirty_prefixes = ["factory/artifacts/"]
+
+[integrity]
+canonicalization = "UTF8_LF_TEXT_RAW_BINARY_V1"
+active_core_manifest = "docs/FROZEN_CORE_V12.sha256"
+active_core_manifest_sha256 = "c58ce36af3d0b993cb45650f8ba7ff7392cc5a23fe50e72c42733c40ef800233"
+pm_dec_007_manifest = "docs/FROZEN_PM_DEC_007_HYBRID_V2.sha256"
+pm_dec_007_manifest_sha256 = "5ab164a66278816dfc849c1117f2ec41f0f6642faef78049deaa368e9597fe7a"
+
+[[integrity.governance]]
+path = "governance/approval-policy.toml"
+sha256 = "9be5ef3804dd8a35681526e9b154d50c0162ba610101dcbabd00ce29996a8708"
+
+[[integrity.governance]]
+path = "governance/risk-policy.toml"
+sha256 = "4f34d45ac058bec6d5ce1ecc05dc242572a917bd6e2f6769ff53b7115f4b72e8"
+
+[routing]
+high = ["architecture", "product", "risk"]
+medium = ["bounded_implementation"]
+low = ["summary", "deterministic_support"]

--- a/factory/decomposition.py
+++ b/factory/decomposition.py
@@ -1,0 +1,82 @@
+"""Owner-bounded Epic decomposition contract for future planners."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import OWNER_GATE_CATEGORIES, Dependency, Registry, Task
+
+
+class OwnerDecisionRequired(ValueError):
+    """Raised when decomposition would exceed approved Owner scope."""
+
+
+@dataclass(frozen=True)
+class ChildTaskDraft:
+    id: str
+    title: str
+    status: str
+    priority: int
+    estimated_minutes: int
+    parent_goal: str
+    capabilities: tuple[str, ...]
+    owner_gate_reasons: tuple[str, ...] = ()
+    is_new_product_idea: bool = False
+    spec_path: str = ""
+    acceptance_path: str = ""
+
+
+def decompose_epic(
+    registry: Registry,
+    epic_id: str,
+    drafts: tuple[ChildTaskDraft, ...],
+    dependencies: tuple[Dependency, ...] = (),
+) -> tuple[tuple[Task, ...], tuple[Dependency, ...]]:
+    try:
+        epic = registry.epic(epic_id)
+    except StopIteration as exc:
+        raise OwnerDecisionRequired(f"missing Epic: {epic_id}") from exc
+    if epic.status != "OWNER_APPROVED":
+        raise OwnerDecisionRequired(f"Epic {epic_id} is {epic.status}, expected OWNER_APPROVED")
+    existing = {task.id for task in registry.tasks}
+    created: list[Task] = []
+    draft_ids = [draft.id for draft in drafts]
+    if len(draft_ids) != len(set(draft_ids)) or existing.intersection(draft_ids):
+        raise ValueError("child task IDs must be unique and new")
+    approved = set(epic.approved_capabilities)
+    for draft in drafts:
+        if draft.parent_goal != epic.goal:
+            raise OwnerDecisionRequired(f"{draft.id} changes the approved Epic goal")
+        expansion = set(draft.capabilities) - approved
+        if expansion:
+            raise OwnerDecisionRequired(f"{draft.id} expands capabilities: {sorted(expansion)}")
+        unknown_gates = set(draft.owner_gate_reasons) - OWNER_GATE_CATEGORIES
+        if unknown_gates:
+            raise ValueError(f"{draft.id} has unknown Owner gates: {sorted(unknown_gates)}")
+        if draft.owner_gate_reasons:
+            raise OwnerDecisionRequired(f"{draft.id} requires Owner: {sorted(draft.owner_gate_reasons)}")
+        if draft.status not in {"PROPOSED", "READY"}:
+            raise ValueError(f"planner child {draft.id} must be PROPOSED or READY")
+        if draft.is_new_product_idea and draft.status != "PROPOSED":
+            raise OwnerDecisionRequired(f"new product idea {draft.id} must remain PROPOSED")
+        created.append(
+            Task(
+                id=draft.id,
+                epic_id=epic_id,
+                title=draft.title,
+                status=draft.status,
+                priority=draft.priority,
+                estimated_minutes=draft.estimated_minutes,
+                spec_path=draft.spec_path,
+                acceptance_path=draft.acceptance_path,
+                capabilities=draft.capabilities,
+                is_new_product_idea=draft.is_new_product_idea,
+            )
+        )
+    all_ids = existing | set(draft_ids)
+    for dependency in dependencies:
+        if dependency.task_id not in draft_ids:
+            raise ValueError(f"decomposition dependency target must be a new child: {dependency.task_id}")
+        if dependency.depends_on not in all_ids or dependency.task_id == dependency.depends_on:
+            raise ValueError(f"invalid child dependency: {dependency}")
+    return tuple(created), dependencies

--- a/factory/github_history.py
+++ b/factory/github_history.py
@@ -1,0 +1,427 @@
+"""Authoritative GitHub Actions daily-run witness for FACTORY-001A."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import Callable
+from zoneinfo import ZoneInfo
+
+
+WORKFLOW_FILE = "daily-factory-control-plane.yml"
+WORKFLOW_PATH = f".github/workflows/{WORKFLOW_FILE}"
+MOSCOW = ZoneInfo("Europe/Moscow")
+API_VERSION = "2022-11-28"
+USER_AGENT = "FACTORY-001A/1"
+PER_PAGE = 100
+MAX_PAGES = 3
+MAX_BODY_BYTES = 2 * 1024 * 1024
+TIMEOUT_SECONDS = 10.0
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+BRANCH_RE = re.compile(r"^[A-Za-z0-9_-][A-Za-z0-9._/-]{0,254}$")
+TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+ALLOWED_STATUSES = frozenset(
+    {"queued", "in_progress", "completed", "waiting", "requested", "pending"}
+)
+ALLOWED_CONCLUSIONS = frozenset(
+    {
+        None,
+        "action_required",
+        "cancelled",
+        "failure",
+        "neutral",
+        "skipped",
+        "stale",
+        "startup_failure",
+        "success",
+        "timed_out",
+    }
+)
+PRODUCTION_EVENTS = frozenset({"schedule", "workflow_dispatch"})
+
+
+class GitHubHistoryError(ValueError):
+    """Raised when workflow history is consuming, incomplete, or untrusted."""
+
+
+@dataclass(frozen=True)
+class _GitHubContext:
+    token: str
+    repository: str
+    run_id: int
+    run_attempt: int
+    ref: str
+    branch: str
+    workflow_path: str
+    api_url: str
+
+
+@dataclass(frozen=True)
+class _WorkflowMetadata:
+    workflow_id: int
+    path: str
+    state: str
+
+
+@dataclass(frozen=True)
+class _WorkflowRun:
+    run_id: int
+    run_attempt: int
+    workflow_id: int
+    event: str
+    status: str
+    conclusion: str | None
+    run_started_at: datetime
+    repository: str
+    branch: str
+
+
+@dataclass(frozen=True)
+class GitHubHistoryWitness:
+    current_run_id: int
+    workflow_id: int
+    checked_runs: int
+
+
+Transport = Callable[[str, dict[str, str], float], tuple[int, bytes]]
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
+def github_actions_enabled() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name)
+    if not isinstance(value, str) or not value or any(character.isspace() for character in value):
+        raise GitHubHistoryError(f"missing or malformed trusted environment field: {name}")
+    return value
+
+
+def _positive_integer(value: str, name: str) -> int:
+    if not value.isascii() or not value.isdecimal():
+        raise GitHubHistoryError(f"malformed trusted environment field: {name}")
+    parsed = int(value)
+    if parsed <= 0 or str(parsed) != value:
+        raise GitHubHistoryError(f"malformed trusted environment field: {name}")
+    return parsed
+
+
+def _valid_branch(branch: str) -> bool:
+    if (
+        not BRANCH_RE.fullmatch(branch)
+        or branch.endswith(("/", "."))
+        or "//" in branch
+        or ".." in branch
+    ):
+        return False
+    return all(
+        component
+        and not component.startswith(".")
+        and not component.lower().endswith(".lock")
+        for component in branch.split("/")
+    )
+
+
+def _load_github_context() -> _GitHubContext:
+    if not github_actions_enabled():
+        raise GitHubHistoryError("GitHub Actions witness requested outside GITHUB_ACTIONS")
+    token = _required_environment("FACTORY_GITHUB_TOKEN")
+    if len(token) > 4096:
+        raise GitHubHistoryError("malformed trusted environment field: FACTORY_GITHUB_TOKEN")
+    repository = _required_environment("GITHUB_REPOSITORY")
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise GitHubHistoryError("malformed trusted environment field: GITHUB_REPOSITORY")
+    run_id = _positive_integer(_required_environment("GITHUB_RUN_ID"), "GITHUB_RUN_ID")
+    run_attempt = _positive_integer(
+        _required_environment("GITHUB_RUN_ATTEMPT"), "GITHUB_RUN_ATTEMPT"
+    )
+    ref = _required_environment("GITHUB_REF")
+    if not ref.startswith("refs/heads/"):
+        raise GitHubHistoryError("trusted GITHUB_REF must be a branch ref")
+    branch = ref.removeprefix("refs/heads/")
+    if not _valid_branch(branch):
+        raise GitHubHistoryError("malformed trusted branch ref")
+    if _required_environment("GITHUB_REF_NAME") != branch:
+        raise GitHubHistoryError("trusted GitHub ref and branch name are inconsistent")
+    ref_type = os.environ.get("GITHUB_REF_TYPE")
+    if ref_type is not None and ref_type != "branch":
+        raise GitHubHistoryError("trusted GITHUB_REF_TYPE must be branch")
+    workflow_ref = _required_environment("GITHUB_WORKFLOW_REF")
+    expected_workflow_ref = f"{repository}/{WORKFLOW_PATH}@{ref}"
+    if workflow_ref != expected_workflow_ref:
+        raise GitHubHistoryError("trusted GitHub workflow identity is inconsistent")
+    api_url = _required_environment("GITHUB_API_URL").rstrip("/")
+    parsed_url = urllib.parse.urlsplit(api_url)
+    if (
+        parsed_url.scheme != "https"
+        or not parsed_url.netloc
+        or parsed_url.username is not None
+        or parsed_url.password is not None
+        or parsed_url.query
+        or parsed_url.fragment
+    ):
+        raise GitHubHistoryError("malformed trusted environment field: GITHUB_API_URL")
+    return _GitHubContext(
+        token,
+        repository,
+        run_id,
+        run_attempt,
+        ref,
+        branch,
+        WORKFLOW_PATH,
+        api_url,
+    )
+
+
+def _github_transport(url: str, headers: dict[str, str], timeout: float) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, method="GET", headers=headers)
+    opener = urllib.request.build_opener(_NoRedirect())
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            body = response.read(MAX_BODY_BYTES + 1)
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        raise GitHubHistoryError(f"GitHub Actions history HTTP status {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, socket.timeout, OSError) as exc:
+        raise GitHubHistoryError("GitHub Actions history request unavailable") from exc
+    if len(body) > MAX_BODY_BYTES:
+        raise GitHubHistoryError("GitHub Actions history response exceeds size limit")
+    return status, body
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise GitHubHistoryError(f"malformed GitHub Actions response: duplicate field {key}")
+        value[key] = item
+    return value
+
+
+def _load_json_object(body: bytes, location: str) -> dict[str, object]:
+    if not isinstance(body, bytes) or len(body) > MAX_BODY_BYTES:
+        raise GitHubHistoryError(f"malformed GitHub Actions {location} response")
+    try:
+        value = json.loads(body.decode("utf-8"), object_pairs_hook=_unique_json_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitHubHistoryError(f"malformed GitHub Actions {location} response") from exc
+    if not isinstance(value, dict):
+        raise GitHubHistoryError(f"malformed GitHub Actions {location} response")
+    return value
+
+
+def _positive_int_field(value: object, location: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}")
+    return value
+
+
+def _text_field(value: object, location: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512:
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}")
+    return value
+
+
+def _parse_timestamp(value: object, location: str) -> datetime:
+    text = _text_field(value, location)
+    if not TIMESTAMP_RE.fullmatch(text):
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}")
+    try:
+        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}") from exc
+
+
+def _parse_metadata(body: bytes, expected_path: str) -> _WorkflowMetadata:
+    value = _load_json_object(body, "workflow metadata")
+    metadata = _WorkflowMetadata(
+        workflow_id=_positive_int_field(value.get("id"), "workflow.id"),
+        path=_text_field(value.get("path"), "workflow.path"),
+        state=_text_field(value.get("state"), "workflow.state"),
+    )
+    if metadata.path != expected_path:
+        raise GitHubHistoryError("workflow metadata path does not match trusted workflow path")
+    if metadata.state != "active":
+        raise GitHubHistoryError("trusted workflow metadata is not active")
+    return metadata
+
+
+def _parse_run(value: object, location: str) -> _WorkflowRun:
+    if not isinstance(value, dict):
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}")
+    repository = value.get("repository")
+    if not isinstance(repository, dict):
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}.repository")
+    conclusion = value.get("conclusion")
+    if conclusion not in ALLOWED_CONCLUSIONS:
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}.conclusion")
+    status = _text_field(value.get("status"), f"{location}.status")
+    if status not in ALLOWED_STATUSES:
+        raise GitHubHistoryError(f"malformed GitHub Actions field: {location}.status")
+    return _WorkflowRun(
+        run_id=_positive_int_field(value.get("id"), f"{location}.id"),
+        run_attempt=_positive_int_field(
+            value.get("run_attempt"), f"{location}.run_attempt"
+        ),
+        workflow_id=_positive_int_field(
+            value.get("workflow_id"), f"{location}.workflow_id"
+        ),
+        event=_text_field(value.get("event"), f"{location}.event"),
+        status=status,
+        conclusion=conclusion,
+        run_started_at=_parse_timestamp(
+            value.get("run_started_at"), f"{location}.run_started_at"
+        ),
+        repository=_text_field(
+            repository.get("full_name"), f"{location}.repository.full_name"
+        ),
+        branch=_text_field(value.get("head_branch"), f"{location}.head_branch"),
+    )
+
+
+def _parse_runs_page(body: bytes, page: int) -> tuple[int, tuple[_WorkflowRun, ...]]:
+    value = _load_json_object(body, "workflow runs")
+    total_count = value.get("total_count")
+    runs = value.get("workflow_runs")
+    if type(total_count) is not int or total_count < 0:
+        raise GitHubHistoryError("malformed GitHub Actions workflow runs total_count")
+    if not isinstance(runs, list) or len(runs) > PER_PAGE:
+        raise GitHubHistoryError("malformed GitHub Actions workflow runs list")
+    return total_count, tuple(
+        _parse_run(item, f"page[{page}].workflow_runs[{index}]")
+        for index, item in enumerate(runs)
+    )
+
+
+def _request(
+    url: str,
+    headers: dict[str, str],
+    transport: Transport,
+    response_name: str,
+) -> bytes:
+    try:
+        status, body = transport(url, dict(headers), TIMEOUT_SECONDS)
+    except GitHubHistoryError:
+        raise
+    except (TimeoutError, socket.timeout, OSError) as exc:
+        raise GitHubHistoryError(f"GitHub Actions {response_name} request unavailable") from exc
+    if status != 200:
+        raise GitHubHistoryError(f"GitHub Actions {response_name} HTTP status {status}")
+    if not isinstance(body, bytes) or len(body) > MAX_BODY_BYTES:
+        raise GitHubHistoryError(f"malformed GitHub Actions {response_name} response")
+    return body
+
+
+def verify_github_daily_history(run_date: date) -> GitHubHistoryWitness:
+    """Verify authoritative history from trusted GitHub environment and API only."""
+
+    context = _load_github_context()
+    return _verify_github_daily_history_for_test(
+        context, run_date, transport=_github_transport
+    )
+
+
+def _verify_github_daily_history_for_test(
+    context: _GitHubContext,
+    run_date: date,
+    *,
+    transport: Transport,
+) -> GitHubHistoryWitness:
+    """Private deterministic seam for bounded transport tests."""
+
+    if context.run_attempt > 1:
+        raise GitHubHistoryError("GitHub workflow rerun attempt already consumes this production run")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {context.token}",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    encoded_repository = "/".join(
+        urllib.parse.quote(part, safe="") for part in context.repository.split("/", 1)
+    )
+    encoded_workflow_file = urllib.parse.quote(WORKFLOW_FILE, safe="")
+    metadata_url = (
+        f"{context.api_url}/repos/{encoded_repository}/actions/workflows/"
+        f"{encoded_workflow_file}"
+    )
+    metadata = _parse_metadata(
+        _request(metadata_url, headers, transport, "workflow metadata"),
+        context.workflow_path,
+    )
+
+    all_runs: list[_WorkflowRun] = []
+    expected_total: int | None = None
+    seen_ids: set[int] = set()
+    for page in range(1, MAX_PAGES + 1):
+        query = urllib.parse.urlencode(
+            {"branch": context.branch, "per_page": PER_PAGE, "page": page}
+        )
+        runs_url = (
+            f"{context.api_url}/repos/{encoded_repository}/actions/workflows/"
+            f"{metadata.workflow_id}/runs?{query}"
+        )
+        total_count, runs = _parse_runs_page(
+            _request(runs_url, headers, transport, "workflow runs"), page
+        )
+        if expected_total is None:
+            expected_total = total_count
+        elif total_count != expected_total:
+            raise GitHubHistoryError("GitHub Actions workflow history changed during pagination")
+        for run in runs:
+            if run.run_id in seen_ids:
+                raise GitHubHistoryError("duplicate GitHub Actions workflow run ID")
+            if run.workflow_id != metadata.workflow_id:
+                raise GitHubHistoryError("workflow run contradicts resolved workflow ID")
+            if run.repository != context.repository:
+                raise GitHubHistoryError("workflow run contradicts trusted repository")
+            if run.branch != context.branch:
+                raise GitHubHistoryError("workflow run contradicts trusted branch")
+            seen_ids.add(run.run_id)
+            all_runs.append(run)
+        if len(all_runs) >= expected_total:
+            if len(all_runs) != expected_total:
+                raise GitHubHistoryError("inconsistent GitHub Actions workflow run count")
+            break
+        if not runs:
+            raise GitHubHistoryError("truncated GitHub Actions workflow history pagination")
+    else:
+        raise GitHubHistoryError("truncated GitHub Actions workflow history pagination")
+
+    current: _WorkflowRun | None = None
+    for run in all_runs:
+        if run.run_id == context.run_id:
+            if current is not None:
+                raise GitHubHistoryError("duplicate current GitHub workflow run witness")
+            current = run
+    if current is None:
+        raise GitHubHistoryError("current GitHub workflow run is absent from authoritative history")
+    if (
+        current.run_attempt != context.run_attempt
+        or current.event not in PRODUCTION_EVENTS
+        or current.run_started_at.astimezone(MOSCOW).date() != run_date
+    ):
+        raise GitHubHistoryError("current GitHub workflow run witness is inconsistent")
+
+    consuming_prior = tuple(
+        run.run_id
+        for run in all_runs
+        if run.run_id != current.run_id
+        and run.event in PRODUCTION_EVENTS
+        and run.run_started_at.astimezone(MOSCOW).date() == run_date
+    )
+    if consuming_prior:
+        raise GitHubHistoryError("Moscow production date is already consumed by a prior workflow run")
+    return GitHubHistoryWitness(context.run_id, metadata.workflow_id, len(all_runs))

--- a/factory/integrity.py
+++ b/factory/integrity.py
@@ -1,0 +1,105 @@
+"""Canonical frozen/governance evidence checks for FACTORY-001A."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from .models import DailyConfig
+
+
+MANIFEST_LINE = re.compile(r"^([0-9a-f]{64})\s+\*?(.+)$")
+BINARY_SUFFIXES = frozenset({".zip", ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".sqlite", ".db"})
+
+
+def safe_repo_path(root: Path, relative: str) -> Path:
+    candidate = (root / relative).resolve()
+    resolved_root = root.resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"path escapes repository: {relative}") from exc
+    return candidate
+
+
+def canonical_bytes(path: Path) -> bytes:
+    raw = path.read_bytes()
+    if path.suffix.lower() in BINARY_SUFFIXES:
+        return raw
+    text = raw.decode("utf-8")
+    return text.replace("\r\n", "\n").replace("\r", "\n").encode("utf-8")
+
+
+def canonical_sha256(path: Path) -> str:
+    return hashlib.sha256(canonical_bytes(path)).hexdigest()
+
+
+def parse_manifest(root: Path, manifest_path: str) -> tuple[tuple[str, str], ...]:
+    path = safe_repo_path(root, manifest_path)
+    entries: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for number, line in enumerate(canonical_bytes(path).decode("utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        match = MANIFEST_LINE.fullmatch(line)
+        if not match:
+            raise ValueError(f"invalid manifest line {manifest_path}:{number}")
+        digest, relative = match.groups()
+        relative = relative.strip().replace("\\", "/")
+        if relative in seen:
+            raise ValueError(f"duplicate manifest path: {relative}")
+        safe_repo_path(root, relative)
+        seen.add(relative)
+        entries.append((relative, digest))
+    if not entries:
+        raise ValueError(f"empty manifest: {manifest_path}")
+    return tuple(entries)
+
+
+def verify_manifest(root: Path, manifest_path: str, expected_manifest_sha256: str) -> tuple[str, ...]:
+    errors: list[str] = []
+    path = safe_repo_path(root, manifest_path)
+    try:
+        actual_manifest = canonical_sha256(path)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return (f"cannot read manifest {manifest_path}: {exc}",)
+    if actual_manifest != expected_manifest_sha256:
+        errors.append(f"manifest hash mismatch: {manifest_path}")
+    try:
+        entries = parse_manifest(root, manifest_path)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return tuple(errors + [str(exc)])
+    for relative, expected in entries:
+        target = safe_repo_path(root, relative)
+        if not target.is_file():
+            errors.append(f"missing frozen artifact: {relative}")
+            continue
+        try:
+            actual = canonical_sha256(target)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"cannot hash frozen artifact {relative}: {exc}")
+            continue
+        if actual != expected:
+            errors.append(f"frozen artifact mismatch: {relative}")
+    return tuple(errors)
+
+
+def verify_integrity(root: Path, config: DailyConfig) -> tuple[str, ...]:
+    errors = list(
+        verify_manifest(root, config.active_core_manifest, config.active_core_manifest_sha256)
+    )
+    errors.extend(verify_manifest(root, config.pm_dec_007_manifest, config.pm_dec_007_manifest_sha256))
+    for evidence in config.governance:
+        path = safe_repo_path(root, evidence.path)
+        if not path.is_file():
+            errors.append(f"missing governance artifact: {evidence.path}")
+            continue
+        try:
+            actual = canonical_sha256(path)
+        except (OSError, UnicodeDecodeError) as exc:
+            errors.append(f"cannot hash governance artifact {evidence.path}: {exc}")
+            continue
+        if actual != evidence.sha256:
+            errors.append(f"governance artifact mismatch: {evidence.path}")
+    return tuple(errors)

--- a/factory/models.py
+++ b/factory/models.py
@@ -1,0 +1,186 @@
+"""Typed registry and daily-run models for FACTORY-001A."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+TASK_STATUSES = frozenset(
+    {
+        "IDEA",
+        "PROPOSED",
+        "OWNER_APPROVED",
+        "READY",
+        "RUNNING",
+        "REVIEW",
+        "NEEDS_OWNER",
+        "BLOCKED",
+        "FAILED",
+        "DONE",
+        "SUPERSEDED",
+    }
+)
+
+RUN_STATUSES = frozenset(
+    {
+        "SCHEDULED",
+        "PREFLIGHT",
+        "TASK_SELECTED",
+        "PLAN_CREATED",
+        "REPORT_CREATED",
+        "NO_WORK",
+        "BLOCKED",
+        "NEEDS_OWNER",
+        "FAILED",
+    }
+)
+
+ACTIVE_RUN_STATUSES = frozenset({"SCHEDULED", "PREFLIGHT", "TASK_SELECTED", "PLAN_CREATED"})
+STOP_RUN_STATUSES = frozenset({"NO_WORK", "BLOCKED", "NEEDS_OWNER", "FAILED"})
+
+OWNER_GATE_CATEGORIES = frozenset(
+    {
+        "new_fundamental_entity",
+        "system_boundary",
+        "external_service",
+        "auth_secrets",
+        "exchange",
+        "market",
+        "lifecycle",
+        "risk_architecture",
+        "global_navigation",
+        "paper_live",
+        "financial_authority",
+        "governance",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Epic:
+    id: str
+    title: str
+    goal: str
+    status: str
+    approved_capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Task:
+    id: str
+    epic_id: str
+    title: str
+    status: str
+    priority: int
+    estimated_minutes: int
+    spec_path: str = ""
+    acceptance_path: str = ""
+    capabilities: tuple[str, ...] = ()
+    owner_gate_reasons: tuple[str, ...] = ()
+    is_new_product_idea: bool = False
+    mandatory_context: tuple[str, ...] = ()
+    relevant_context: tuple[str, ...] = ()
+    frozen_context: tuple[str, ...] = ()
+    skip_context: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Dependency:
+    task_id: str
+    depends_on: str
+
+
+@dataclass(frozen=True)
+class OwnerDecision:
+    id: str
+    subject_id: str
+    status: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    id: str
+    status: str
+    date: str
+    selected_task_id: str = ""
+
+
+@dataclass(frozen=True)
+class Registry:
+    schema_version: int
+    epics: tuple[Epic, ...] = ()
+    tasks: tuple[Task, ...] = ()
+    dependencies: tuple[Dependency, ...] = ()
+    owner_decisions: tuple[OwnerDecision, ...] = ()
+    runs: tuple[RunRecord, ...] = ()
+
+    def epic(self, epic_id: str) -> Epic:
+        return next(item for item in self.epics if item.id == epic_id)
+
+    def task(self, task_id: str) -> Task:
+        return next(item for item in self.tasks if item.id == task_id)
+
+    def dependencies_for(self, task_id: str) -> tuple[Dependency, ...]:
+        return tuple(item for item in self.dependencies if item.task_id == task_id)
+
+
+@dataclass(frozen=True)
+class GovernanceEvidence:
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class DailyConfig:
+    schema_version: int
+    timezone: str
+    max_tasks_per_day: int
+    max_parallel_writers: int
+    max_correction_loops: int
+    max_run_time_minutes: int
+    auto_merge: bool
+    auto_product_approval: bool
+    paper_authority: bool
+    live_authority: bool
+    allow_dirty: bool
+    allowed_dirty_prefixes: tuple[str, ...]
+    canonicalization: str
+    active_core_manifest: str
+    active_core_manifest_sha256: str
+    pm_dec_007_manifest: str
+    pm_dec_007_manifest_sha256: str
+    governance: tuple[GovernanceEvidence, ...]
+    routing: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RepositoryState:
+    known: bool
+    dirty_paths: tuple[str, ...] = ()
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    status: str
+    selected_task: Task | None
+    checks: tuple[CheckResult, ...]
+    blockers: tuple[str, ...] = ()
+    owner_decisions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    date: str
+    status: str
+    selected_task_id: str
+    plan_path: str
+    report_path: str

--- a/factory/planning.py
+++ b/factory/planning.py
@@ -1,0 +1,194 @@
+"""Deterministic execution-plan and Owner Report generation."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from .integrity import safe_repo_path
+from .models import DailyConfig, PreflightResult, Registry, Task
+
+
+def pipeline_preview(root: Path) -> tuple[dict[str, Any], ...]:
+    path = root / "factory/pipeline.toml"
+    with path.open("rb") as handle:
+        pipeline = tomllib.load(handle)
+    preview: list[dict[str, Any]] = []
+    for stage in pipeline.get("stages", []):
+        preview.append(
+            {
+                "id": stage.get("id", ""),
+                "agents": tuple(stage.get("agents", [])),
+                "mode": stage.get("mode", ""),
+            }
+        )
+    return tuple(preview)
+
+
+def build_execution_plan(
+    root: Path,
+    registry: Registry,
+    config: DailyConfig,
+    task: Task,
+    run_date: str,
+) -> dict[str, Any]:
+    epic = registry.epic(task.epic_id)
+    dependencies = tuple(dependency.depends_on for dependency in registry.dependencies_for(task.id))
+    return {
+        "schema_version": 1,
+        "date": run_date,
+        "run_mode": "DRY_RUN",
+        "epic": {"id": epic.id, "title": epic.title},
+        "selected_task": {"id": task.id, "title": task.title, "priority": task.priority},
+        "why_this_task": "highest-priority eligible READY task after deterministic preflight",
+        "dependencies": dependencies,
+        "limits": {
+            "max_tasks_per_day": config.max_tasks_per_day,
+            "max_parallel_writers": config.max_parallel_writers,
+            "max_correction_loops": config.max_correction_loops,
+            "max_run_time_minutes": config.max_run_time_minutes,
+        },
+        "token_plan": {
+            "MANDATORY": task.mandatory_context,
+            "RELEVANT": task.relevant_context,
+            "FROZEN": task.frozen_context,
+            "SKIP": task.skip_context,
+        },
+        "agent_routing_policy": config.routing,
+        "pipeline_preview_only": pipeline_preview(root),
+        "authority": {
+            "auto_merge": config.auto_merge,
+            "auto_product_approval": config.auto_product_approval,
+            "paper_authority": config.paper_authority,
+            "live_authority": config.live_authority,
+            "coding_agent_invocation": False,
+            "commit": False,
+            "push": False,
+            "pull_request": False,
+        },
+        "ai_usage": 0,
+        "next_action": "Owner reviews the plan; FACTORY-001A invokes no coding agent.",
+    }
+
+
+def _display_list(values: tuple[str, ...] | list[str]) -> str:
+    return "NONE" if not values else "\n".join(f"- {value}" for value in values)
+
+
+def render_owner_report(
+    registry: Registry,
+    config: DailyConfig,
+    preflight: PreflightResult,
+    run_date: str,
+    run_status: str,
+    plan: dict[str, Any] | None,
+) -> str:
+    task = preflight.selected_task
+    epic = registry.epic(task.epic_id) if task else None
+    dependencies = (
+        tuple(dependency.depends_on for dependency in registry.dependencies_for(task.id)) if task else ()
+    )
+    decisions = tuple(
+        f"{item.id} [{item.status}] — {item.summary}"
+        for item in sorted(registry.owner_decisions, key=lambda item: item.id)
+    )
+    if plan:
+        what_next = plan["pipeline_preview_only"][0]["id"] if plan["pipeline_preview_only"] else "NONE"
+        why = plan["why_this_task"]
+    else:
+        what_next = "NONE"
+        why = "No task was authorized for planning."
+    if run_status == "NEEDS_OWNER":
+        next_action = "Owner resolves the listed decision; the pipeline remains stopped."
+    elif run_status == "BLOCKED":
+        next_action = "Correct the deterministic blocker and rerun preflight."
+    elif run_status == "NO_WORK":
+        next_action = "Owner approves work; then a contracted task may be marked READY."
+    elif run_status == "REPORT_CREATED":
+        next_action = "Owner reviews this plan. FACTORY-001A will not invoke a coding agent."
+    else:
+        next_action = "Investigate the failed deterministic run."
+    token_plan = plan["token_plan"] if plan else {"MANDATORY": (), "RELEVANT": (), "FROZEN": (), "SKIP": ()}
+    token_lines = []
+    for label in ("MANDATORY", "RELEVANT", "FROZEN", "SKIP"):
+        values = token_plan[label]
+        token_lines.append(f"- {label}: {', '.join(values) if values else 'NONE'}")
+    blockers = tuple(preflight.blockers) + tuple(preflight.owner_decisions)
+    return "\n".join(
+        (
+            "# FACTORY-001A Owner Report",
+            "",
+            "## DATE",
+            run_date,
+            "",
+            "## RUN STATUS",
+            run_status,
+            "",
+            "## EPIC",
+            f"{epic.id} — {epic.title}" if epic else "NONE",
+            "",
+            "## SELECTED TASK",
+            f"{task.id} — {task.title}" if task else "NONE",
+            "",
+            "## WHY THIS TASK",
+            why,
+            "",
+            "## DEPENDENCIES",
+            _display_list(dependencies),
+            "",
+            "## WHAT WOULD RUN NEXT",
+            what_next,
+            "",
+            "## OWNER DECISIONS",
+            _display_list(decisions),
+            "",
+            "## BLOCKERS",
+            _display_list(blockers),
+            "",
+            "## TOKEN PLAN",
+            "\n".join(token_lines),
+            "",
+            "## AI_USAGE",
+            "0",
+            "",
+            "## NEXT ACTION",
+            next_action,
+            "",
+        )
+    )
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def write_plan(root: Path, output_dir: str, run_date: str, plan: dict[str, Any]) -> Path:
+    directory = safe_repo_path(root, output_dir)
+    path = directory / f"{run_date}-execution-plan.json"
+    content = json.dumps(plan, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    atomic_write_text(path, content)
+    return path
+
+
+def write_report(root: Path, output_dir: str, run_date: str, report: str) -> Path:
+    directory = safe_repo_path(root, output_dir)
+    path = directory / f"{run_date}-owner-report.md"
+    atomic_write_text(path, report)
+    return path

--- a/factory/preflight.py
+++ b/factory/preflight.py
@@ -1,0 +1,176 @@
+"""Fail-closed deterministic preflight and READY-task selection."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from .integrity import safe_repo_path, verify_integrity
+from .models import (
+    ACTIVE_RUN_STATUSES,
+    CheckResult,
+    DailyConfig,
+    PreflightResult,
+    Registry,
+    RepositoryState,
+    Task,
+)
+from .repository import disallowed_dirty_paths, probe_repository
+
+
+def _result(
+    status: str,
+    checks: list[CheckResult],
+    *,
+    task: Task | None = None,
+    blockers: tuple[str, ...] = (),
+    decisions: tuple[str, ...] = (),
+) -> PreflightResult:
+    return PreflightResult(status, task, tuple(checks), blockers, decisions)
+
+
+def _contracts(root: Path, task: Task) -> tuple[str, ...]:
+    errors: list[str] = []
+    if not task.spec_path:
+        errors.append(f"{task.id} has no spec_path")
+    if not task.acceptance_path:
+        errors.append(f"{task.id} has no acceptance_path")
+    for label, relative in (("spec", task.spec_path), ("acceptance", task.acceptance_path)):
+        if not relative:
+            continue
+        try:
+            path = safe_repo_path(root, relative)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if not path.is_file():
+            errors.append(f"{task.id} missing {label}: {relative}")
+    return tuple(errors)
+
+
+def _dependency_blockers(registry: Registry, task: Task) -> tuple[str, ...]:
+    blockers: list[str] = []
+    for dependency in registry.dependencies_for(task.id):
+        parent = registry.task(dependency.depends_on)
+        if parent.status != "DONE":
+            blockers.append(f"{task.id} depends on {parent.id}={parent.status}, expected DONE")
+    return tuple(blockers)
+
+
+def run_preflight(
+    registry: Registry,
+    config: DailyConfig,
+    root: Path,
+    run_date: date,
+    *,
+    repository_state: RepositoryState | None = None,
+    integrity_issues: tuple[str, ...] | None = None,
+) -> PreflightResult:
+    checks: list[CheckResult] = []
+
+    active = tuple(run.id for run in registry.runs if run.status in ACTIVE_RUN_STATUSES)
+    checks.append(CheckResult("single_active_run", not active, "none" if not active else ", ".join(active)))
+    if active:
+        return _result("BLOCKED", checks, blockers=(f"active run exists: {', '.join(active)}",))
+
+    unresolved = tuple(
+        f"{decision.id}: {decision.summary}"
+        for decision in registry.owner_decisions
+        if decision.status == "NEEDS_OWNER"
+    )
+    unresolved += tuple(
+        f"{task.id}: task status NEEDS_OWNER"
+        for task in registry.tasks
+        if task.status == "NEEDS_OWNER"
+    )
+    checks.append(
+        CheckResult(
+            "unresolved_owner_decisions",
+            not unresolved,
+            "none" if not unresolved else "; ".join(unresolved),
+        )
+    )
+    if unresolved:
+        return _result("NEEDS_OWNER", checks, decisions=unresolved)
+
+    if integrity_issues is None:
+        integrity_issues = verify_integrity(root, config)
+    checks.append(
+        CheckResult(
+            "governance_and_frozen_evidence",
+            not integrity_issues,
+            "pass" if not integrity_issues else "; ".join(integrity_issues),
+        )
+    )
+    if integrity_issues:
+        return _result("BLOCKED", checks, blockers=integrity_issues)
+
+    state = repository_state if repository_state is not None else probe_repository(root)
+    dirty = disallowed_dirty_paths(state, config.allowed_dirty_prefixes)
+    checks.append(
+        CheckResult(
+            "repository_state",
+            not dirty,
+            "clean/admissible" if not dirty else "; ".join(dirty),
+        )
+    )
+    if dirty:
+        return _result("BLOCKED", checks, blockers=dirty)
+
+    selected_today = tuple(
+        run.id for run in registry.runs if run.date == run_date.isoformat() and run.selected_task_id
+    )
+    daily_ok = len(selected_today) < config.max_tasks_per_day
+    checks.append(
+        CheckResult(
+            "daily_task_budget",
+            daily_ok,
+            f"selected={len(selected_today)}, max={config.max_tasks_per_day}",
+        )
+    )
+    if not daily_ok:
+        return _result("BLOCKED", checks, blockers=("daily task budget exhausted",))
+
+    ready = sorted(
+        (task for task in registry.tasks if task.status == "READY"),
+        key=lambda item: (item.priority, item.id),
+    )
+    checks.append(CheckResult("ready_task_exists", bool(ready), f"count={len(ready)}"))
+    if not ready:
+        return _result("NO_WORK", checks)
+
+    blocked_candidates: list[str] = []
+    for task in ready:
+        if task.owner_gate_reasons:
+            reasons = tuple(f"{task.id}: {reason}" for reason in task.owner_gate_reasons)
+            checks.append(CheckResult("owner_decision_gate", False, "; ".join(reasons)))
+            return _result("NEEDS_OWNER", checks, decisions=reasons)
+        contract_errors = _contracts(root, task)
+        if contract_errors:
+            blocked_candidates.extend(contract_errors)
+            continue
+        dependency_errors = _dependency_blockers(registry, task)
+        if dependency_errors:
+            blocked_candidates.extend(dependency_errors)
+            continue
+        if task.estimated_minutes > config.max_run_time_minutes:
+            blocked_candidates.append(
+                f"{task.id} estimate {task.estimated_minutes} exceeds {config.max_run_time_minutes} minutes"
+            )
+            continue
+        checks.extend(
+            (
+                CheckResult("task_contract", True, f"{task.spec_path}; {task.acceptance_path}"),
+                CheckResult("dependencies_done", True, task.id),
+                CheckResult(
+                    "runtime_budget",
+                    True,
+                    f"{task.estimated_minutes}/{config.max_run_time_minutes}",
+                ),
+                CheckResult("task_selected", True, task.id),
+            )
+        )
+        return _result("TASK_SELECTED", checks, task=task)
+
+    checks.append(CheckResult("eligible_ready_task", False, "; ".join(blocked_candidates)))
+    return _result("BLOCKED", checks, blockers=tuple(blocked_candidates))

--- a/factory/preflight.py
+++ b/factory/preflight.py
@@ -16,6 +16,7 @@ from .models import (
     Task,
 )
 from .repository import disallowed_dirty_paths, probe_repository
+from .registry import RegistryError, validate_registry
 
 
 def _result(
@@ -48,6 +49,41 @@ def _contracts(root: Path, task: Task) -> tuple[str, ...]:
     return tuple(errors)
 
 
+def _context_evidence(root: Path, task: Task) -> tuple[str, ...]:
+    errors: list[str] = []
+    for field, values in (
+        ("mandatory_context", task.mandatory_context),
+        ("relevant_context", task.relevant_context),
+        ("frozen_context", task.frozen_context),
+    ):
+        for relative in values:
+            try:
+                path = safe_repo_path(root, relative)
+            except ValueError as exc:
+                errors.append(str(exc))
+                continue
+            if not path.is_file():
+                errors.append(f"{task.id} missing {field}: {relative}")
+    return tuple(errors)
+
+
+def _ready_authority_errors(registry: Registry, task: Task) -> tuple[str, ...]:
+    try:
+        epic = registry.epic(task.epic_id)
+    except StopIteration:
+        return (f"READY task {task.id} references missing Epic {task.epic_id}",)
+    errors: list[str] = []
+    if epic.status != "OWNER_APPROVED":
+        errors.append(f"READY task {task.id} requires OWNER_APPROVED Epic {epic.id}")
+    extra_capabilities = sorted(set(task.capabilities) - set(epic.approved_capabilities))
+    if extra_capabilities:
+        errors.append(
+            f"READY task {task.id} exceeds Epic {epic.id} approved capabilities: "
+            f"{extra_capabilities}"
+        )
+    return tuple(errors)
+
+
 def _dependency_blockers(registry: Registry, task: Task) -> tuple[str, ...]:
     blockers: list[str] = []
     for dependency in registry.dependencies_for(task.id):
@@ -62,11 +98,60 @@ def run_preflight(
     config: DailyConfig,
     root: Path,
     run_date: date,
-    *,
-    repository_state: RepositoryState | None = None,
-    integrity_issues: tuple[str, ...] | None = None,
 ) -> PreflightResult:
+    """Run production preflight using only canonical repository and integrity probes."""
+
+    return _evaluate_preflight(
+        registry,
+        config,
+        root,
+        run_date,
+        repository_state=probe_repository(root),
+        integrity_issues=verify_integrity(root, config),
+    )
+
+
+def _run_preflight_for_test(
+    registry: Registry,
+    config: DailyConfig,
+    root: Path,
+    run_date: date,
+    *,
+    repository_state: RepositoryState,
+    integrity_issues: tuple[str, ...],
+) -> PreflightResult:
+    """Private deterministic boundary for tests with explicit probe evidence."""
+
+    return _evaluate_preflight(
+        registry,
+        config,
+        root,
+        run_date,
+        repository_state=repository_state,
+        integrity_issues=integrity_issues,
+    )
+
+
+def _evaluate_preflight(
+    registry: Registry,
+    config: DailyConfig,
+    root: Path,
+    run_date: date,
+    *,
+    repository_state: RepositoryState,
+    integrity_issues: tuple[str, ...],
+) -> PreflightResult:
+    """Evaluate already-probed evidence behind private production/test boundaries."""
+
     checks: list[CheckResult] = []
+
+    try:
+        validate_registry(registry, root=root)
+    except RegistryError as exc:
+        detail = str(exc)
+        checks.append(CheckResult("registry_valid", False, detail))
+        return _result("BLOCKED", checks, blockers=(detail,))
+    checks.append(CheckResult("registry_valid", True, "pass"))
 
     active = tuple(run.id for run in registry.runs if run.status in ACTIVE_RUN_STATUSES)
     checks.append(CheckResult("single_active_run", not active, "none" if not active else ", ".join(active)))
@@ -93,8 +178,6 @@ def run_preflight(
     if unresolved:
         return _result("NEEDS_OWNER", checks, decisions=unresolved)
 
-    if integrity_issues is None:
-        integrity_issues = verify_integrity(root, config)
     checks.append(
         CheckResult(
             "governance_and_frozen_evidence",
@@ -105,8 +188,7 @@ def run_preflight(
     if integrity_issues:
         return _result("BLOCKED", checks, blockers=integrity_issues)
 
-    state = repository_state if repository_state is not None else probe_repository(root)
-    dirty = disallowed_dirty_paths(state, config.allowed_dirty_prefixes)
+    dirty = disallowed_dirty_paths(repository_state, config.allowed_dirty_prefixes)
     checks.append(
         CheckResult(
             "repository_state",
@@ -141,18 +223,26 @@ def run_preflight(
 
     blocked_candidates: list[str] = []
     for task in ready:
+        authority_errors = _ready_authority_errors(registry, task)
+        if authority_errors:
+            checks.append(CheckResult("ready_authority", False, "; ".join(authority_errors)))
+            return _result("BLOCKED", checks, blockers=authority_errors)
         if task.owner_gate_reasons:
             reasons = tuple(f"{task.id}: {reason}" for reason in task.owner_gate_reasons)
             checks.append(CheckResult("owner_decision_gate", False, "; ".join(reasons)))
             return _result("NEEDS_OWNER", checks, decisions=reasons)
         contract_errors = _contracts(root, task)
         if contract_errors:
-            blocked_candidates.extend(contract_errors)
-            continue
+            checks.append(CheckResult("task_contract", False, "; ".join(contract_errors)))
+            return _result("BLOCKED", checks, blockers=contract_errors)
+        evidence_errors = _context_evidence(root, task)
+        if evidence_errors:
+            checks.append(CheckResult("task_context_evidence", False, "; ".join(evidence_errors)))
+            return _result("BLOCKED", checks, blockers=evidence_errors)
         dependency_errors = _dependency_blockers(registry, task)
         if dependency_errors:
-            blocked_candidates.extend(dependency_errors)
-            continue
+            checks.append(CheckResult("dependencies_done", False, "; ".join(dependency_errors)))
+            return _result("BLOCKED", checks, blockers=dependency_errors)
         if task.estimated_minutes > config.max_run_time_minutes:
             blocked_candidates.append(
                 f"{task.id} estimate {task.estimated_minutes} exceeds {config.max_run_time_minutes} minutes"
@@ -161,6 +251,7 @@ def run_preflight(
         checks.extend(
             (
                 CheckResult("task_contract", True, f"{task.spec_path}; {task.acceptance_path}"),
+                CheckResult("task_context_evidence", True, task.id),
                 CheckResult("dependencies_done", True, task.id),
                 CheckResult(
                     "runtime_budget",

--- a/factory/registry.py
+++ b/factory/registry.py
@@ -1,0 +1,267 @@
+"""Strict TOML loading and validation for the FACTORY-001A registry."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from .models import (
+    ACTIVE_RUN_STATUSES,
+    OWNER_GATE_CATEGORIES,
+    RUN_STATUSES,
+    TASK_STATUSES,
+    Dependency,
+    Epic,
+    OwnerDecision,
+    Registry,
+    RunRecord,
+    Task,
+)
+
+
+class RegistryError(ValueError):
+    """Raised when registry input is ambiguous or invalid."""
+
+
+TOP_LEVEL_KEYS = {"schema_version", "epics", "tasks", "dependencies", "owner_decisions", "runs"}
+EPIC_KEYS = {"id", "title", "goal", "status", "approved_capabilities"}
+TASK_KEYS = {
+    "id",
+    "epic_id",
+    "title",
+    "status",
+    "priority",
+    "estimated_minutes",
+    "spec_path",
+    "acceptance_path",
+    "capabilities",
+    "owner_gate_reasons",
+    "is_new_product_idea",
+    "mandatory_context",
+    "relevant_context",
+    "frozen_context",
+    "skip_context",
+}
+DEPENDENCY_KEYS = {"task_id", "depends_on"}
+DECISION_KEYS = {"id", "subject_id", "status", "summary"}
+RUN_KEYS = {"id", "status", "date", "selected_task_id"}
+
+
+def _reject_unknown(data: dict[str, Any], allowed: set[str], location: str) -> None:
+    unknown = sorted(set(data) - allowed)
+    if unknown:
+        raise RegistryError(f"unknown keys at {location}: {unknown}")
+
+
+def _required_text(data: dict[str, Any], key: str, location: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RegistryError(f"{location}.{key} must be non-empty text")
+    return value
+
+
+def _text_tuple(data: dict[str, Any], key: str, location: str) -> tuple[str, ...]:
+    value = data.get(key, [])
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise RegistryError(f"{location}.{key} must be a list of non-empty strings")
+    if len(value) != len(set(value)):
+        raise RegistryError(f"{location}.{key} contains duplicates")
+    return tuple(value)
+
+
+def _safe_relative(path: str, location: str) -> None:
+    if not path:
+        return
+    candidate = Path(path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise RegistryError(f"{location} must remain repository-relative")
+
+
+def load_registry(path: Path) -> Registry:
+    try:
+        with path.open("rb") as handle:
+            raw = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise RegistryError(f"cannot load registry {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RegistryError("registry root must be a table")
+    _reject_unknown(raw, TOP_LEVEL_KEYS, "registry")
+    if raw.get("schema_version") != 1:
+        raise RegistryError("registry.schema_version must be 1")
+
+    epics: list[Epic] = []
+    for index, item in enumerate(raw.get("epics", [])):
+        location = f"epics[{index}]"
+        _reject_unknown(item, EPIC_KEYS, location)
+        epics.append(
+            Epic(
+                id=_required_text(item, "id", location),
+                title=_required_text(item, "title", location),
+                goal=_required_text(item, "goal", location),
+                status=_required_text(item, "status", location),
+                approved_capabilities=_text_tuple(item, "approved_capabilities", location),
+            )
+        )
+
+    tasks: list[Task] = []
+    for index, item in enumerate(raw.get("tasks", [])):
+        location = f"tasks[{index}]"
+        _reject_unknown(item, TASK_KEYS, location)
+        priority = item.get("priority")
+        estimate = item.get("estimated_minutes")
+        if not isinstance(priority, int) or isinstance(priority, bool) or priority < 0:
+            raise RegistryError(f"{location}.priority must be a non-negative integer")
+        if not isinstance(estimate, int) or isinstance(estimate, bool) or estimate <= 0:
+            raise RegistryError(f"{location}.estimated_minutes must be a positive integer")
+        spec_path = item.get("spec_path", "")
+        acceptance_path = item.get("acceptance_path", "")
+        if not isinstance(spec_path, str) or not isinstance(acceptance_path, str):
+            raise RegistryError(f"{location} contract paths must be strings")
+        _safe_relative(spec_path, f"{location}.spec_path")
+        _safe_relative(acceptance_path, f"{location}.acceptance_path")
+        new_idea = item.get("is_new_product_idea", False)
+        if not isinstance(new_idea, bool):
+            raise RegistryError(f"{location}.is_new_product_idea must be boolean")
+        tasks.append(
+            Task(
+                id=_required_text(item, "id", location),
+                epic_id=_required_text(item, "epic_id", location),
+                title=_required_text(item, "title", location),
+                status=_required_text(item, "status", location),
+                priority=priority,
+                estimated_minutes=estimate,
+                spec_path=spec_path,
+                acceptance_path=acceptance_path,
+                capabilities=_text_tuple(item, "capabilities", location),
+                owner_gate_reasons=_text_tuple(item, "owner_gate_reasons", location),
+                is_new_product_idea=new_idea,
+                mandatory_context=_text_tuple(item, "mandatory_context", location),
+                relevant_context=_text_tuple(item, "relevant_context", location),
+                frozen_context=_text_tuple(item, "frozen_context", location),
+                skip_context=_text_tuple(item, "skip_context", location),
+            )
+        )
+
+    dependencies: list[Dependency] = []
+    for index, item in enumerate(raw.get("dependencies", [])):
+        location = f"dependencies[{index}]"
+        _reject_unknown(item, DEPENDENCY_KEYS, location)
+        dependencies.append(
+            Dependency(
+                task_id=_required_text(item, "task_id", location),
+                depends_on=_required_text(item, "depends_on", location),
+            )
+        )
+
+    decisions: list[OwnerDecision] = []
+    for index, item in enumerate(raw.get("owner_decisions", [])):
+        location = f"owner_decisions[{index}]"
+        _reject_unknown(item, DECISION_KEYS, location)
+        decisions.append(
+            OwnerDecision(
+                id=_required_text(item, "id", location),
+                subject_id=_required_text(item, "subject_id", location),
+                status=_required_text(item, "status", location),
+                summary=_required_text(item, "summary", location),
+            )
+        )
+
+    runs: list[RunRecord] = []
+    for index, item in enumerate(raw.get("runs", [])):
+        location = f"runs[{index}]"
+        _reject_unknown(item, RUN_KEYS, location)
+        selected = item.get("selected_task_id", "")
+        if not isinstance(selected, str):
+            raise RegistryError(f"{location}.selected_task_id must be text")
+        runs.append(
+            RunRecord(
+                id=_required_text(item, "id", location),
+                status=_required_text(item, "status", location),
+                date=_required_text(item, "date", location),
+                selected_task_id=selected,
+            )
+        )
+
+    registry = Registry(1, tuple(epics), tuple(tasks), tuple(dependencies), tuple(decisions), tuple(runs))
+    validate_registry(registry)
+    return registry
+
+
+def _unique(values: list[str], kind: str) -> None:
+    if len(values) != len(set(values)):
+        raise RegistryError(f"duplicate {kind} id")
+
+
+def _check_dependency_cycles(registry: Registry) -> None:
+    graph: dict[str, list[str]] = {task.id: [] for task in registry.tasks}
+    for dependency in registry.dependencies:
+        graph[dependency.task_id].append(dependency.depends_on)
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(task_id: str) -> None:
+        if task_id in visiting:
+            raise RegistryError(f"dependency cycle contains {task_id}")
+        if task_id in visited:
+            return
+        visiting.add(task_id)
+        for parent in graph[task_id]:
+            visit(parent)
+        visiting.remove(task_id)
+        visited.add(task_id)
+
+    for task_id in sorted(graph):
+        visit(task_id)
+
+
+def validate_registry(registry: Registry) -> None:
+    epic_ids = [item.id for item in registry.epics]
+    task_ids = [item.id for item in registry.tasks]
+    decision_ids = [item.id for item in registry.owner_decisions]
+    run_ids = [item.id for item in registry.runs]
+    _unique(epic_ids, "Epic")
+    _unique(task_ids, "Task")
+    _unique(decision_ids, "Owner Decision")
+    _unique(run_ids, "Run")
+    epic_set = set(epic_ids)
+    task_set = set(task_ids)
+    subject_set = epic_set | task_set
+
+    for epic in registry.epics:
+        if epic.status not in TASK_STATUSES:
+            raise RegistryError(f"unknown Epic status: {epic.status}")
+    for task in registry.tasks:
+        if task.status not in TASK_STATUSES:
+            raise RegistryError(f"unknown Task status: {task.status}")
+        if task.epic_id not in epic_set:
+            raise RegistryError(f"task {task.id} references missing Epic {task.epic_id}")
+        unknown_gates = set(task.owner_gate_reasons) - OWNER_GATE_CATEGORIES
+        if unknown_gates:
+            raise RegistryError(f"task {task.id} has unknown Owner gates: {sorted(unknown_gates)}")
+        if task.is_new_product_idea and task.status not in {"IDEA", "PROPOSED", "NEEDS_OWNER"}:
+            raise RegistryError(f"new product idea {task.id} must remain IDEA/PROPOSED/NEEDS_OWNER")
+    seen_dependencies: set[tuple[str, str]] = set()
+    for dependency in registry.dependencies:
+        key = (dependency.task_id, dependency.depends_on)
+        if key in seen_dependencies:
+            raise RegistryError(f"duplicate dependency {key}")
+        seen_dependencies.add(key)
+        if dependency.task_id not in task_set or dependency.depends_on not in task_set:
+            raise RegistryError(f"dependency references missing task: {key}")
+        if dependency.task_id == dependency.depends_on:
+            raise RegistryError(f"task {dependency.task_id} cannot depend on itself")
+    _check_dependency_cycles(registry)
+    for decision in registry.owner_decisions:
+        if decision.status not in TASK_STATUSES:
+            raise RegistryError(f"unknown Owner Decision status: {decision.status}")
+        if decision.subject_id not in subject_set:
+            raise RegistryError(f"Owner Decision {decision.id} references missing subject")
+    for run in registry.runs:
+        if run.status not in RUN_STATUSES:
+            raise RegistryError(f"unknown Run status: {run.status}")
+        if run.selected_task_id and run.selected_task_id not in task_set:
+            raise RegistryError(f"Run {run.id} references missing selected task")
+    active = [run.id for run in registry.runs if run.status in ACTIVE_RUN_STATUSES]
+    if len(active) > 1:
+        raise RegistryError(f"more than one active run: {active}")

--- a/factory/registry.py
+++ b/factory/registry.py
@@ -78,7 +78,7 @@ def _safe_relative(path: str, location: str) -> None:
         raise RegistryError(f"{location} must remain repository-relative")
 
 
-def load_registry(path: Path) -> Registry:
+def load_registry(path: Path, *, root: Path | None = None) -> Registry:
     try:
         with path.open("rb") as handle:
             raw = tomllib.load(handle)
@@ -142,6 +142,9 @@ def load_registry(path: Path) -> Registry:
                 skip_context=_text_tuple(item, "skip_context", location),
             )
         )
+        for field in ("mandatory_context", "relevant_context", "frozen_context"):
+            for context_path in getattr(tasks[-1], field):
+                _safe_relative(context_path, f"{location}.{field}")
 
     dependencies: list[Dependency] = []
     for index, item in enumerate(raw.get("dependencies", [])):
@@ -184,7 +187,7 @@ def load_registry(path: Path) -> Registry:
         )
 
     registry = Registry(1, tuple(epics), tuple(tasks), tuple(dependencies), tuple(decisions), tuple(runs))
-    validate_registry(registry)
+    validate_registry(registry, root=root)
     return registry
 
 
@@ -215,7 +218,7 @@ def _check_dependency_cycles(registry: Registry) -> None:
         visit(task_id)
 
 
-def validate_registry(registry: Registry) -> None:
+def validate_registry(registry: Registry, *, root: Path | None = None) -> None:
     epic_ids = [item.id for item in registry.epics]
     task_ids = [item.id for item in registry.tasks]
     decision_ids = [item.id for item in registry.owner_decisions]
@@ -225,6 +228,7 @@ def validate_registry(registry: Registry) -> None:
     _unique(decision_ids, "Owner Decision")
     _unique(run_ids, "Run")
     epic_set = set(epic_ids)
+    epic_by_id = {epic.id: epic for epic in registry.epics}
     task_set = set(task_ids)
     subject_set = epic_set | task_set
 
@@ -236,6 +240,40 @@ def validate_registry(registry: Registry) -> None:
             raise RegistryError(f"unknown Task status: {task.status}")
         if task.epic_id not in epic_set:
             raise RegistryError(f"task {task.id} references missing Epic {task.epic_id}")
+        if task.status == "READY":
+            epic = epic_by_id[task.epic_id]
+            if epic.status != "OWNER_APPROVED":
+                raise RegistryError(
+                    f"READY task {task.id} requires OWNER_APPROVED Epic {epic.id}"
+                )
+            extra_capabilities = sorted(set(task.capabilities) - set(epic.approved_capabilities))
+            if extra_capabilities:
+                raise RegistryError(
+                    f"READY task {task.id} exceeds Epic {epic.id} approved capabilities: "
+                    f"{extra_capabilities}"
+                )
+            if not task.spec_path or not task.acceptance_path:
+                raise RegistryError(f"READY task {task.id} requires spec and acceptance contracts")
+            if root is not None:
+                referenced_paths = (
+                    ("spec", task.spec_path),
+                    ("acceptance", task.acceptance_path),
+                    *(("mandatory_context", item) for item in task.mandatory_context),
+                    *(("relevant_context", item) for item in task.relevant_context),
+                    *(("frozen_context", item) for item in task.frozen_context),
+                )
+                for label, relative in referenced_paths:
+                    candidate = (root.resolve() / relative).resolve()
+                    try:
+                        candidate.relative_to(root.resolve())
+                    except ValueError as exc:
+                        raise RegistryError(
+                            f"READY task {task.id} {label} escapes repository: {relative}"
+                        ) from exc
+                    if not candidate.is_file():
+                        raise RegistryError(
+                            f"READY task {task.id} missing {label}: {relative}"
+                        )
         unknown_gates = set(task.owner_gate_reasons) - OWNER_GATE_CATEGORIES
         if unknown_gates:
             raise RegistryError(f"task {task.id} has unknown Owner gates: {sorted(unknown_gates)}")

--- a/factory/registry.toml
+++ b/factory/registry.toml
@@ -5,7 +5,7 @@ id = "FACTORY-001"
 title = "Daily autonomous development control plane"
 goal = "Plan one bounded Owner-approved development task per day without granting write-agent or trading authority."
 status = "OWNER_APPROVED"
-approved_capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context"]
+approved_capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context", "github_history_witness"]
 
 [[tasks]]
 id = "FACTORY-001A"
@@ -16,7 +16,7 @@ priority = 1
 estimated_minutes = 90
 spec_path = "specs/factory-001a/spec.md"
 acceptance_path = "specs/factory-001a/acceptance.toml"
-capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context"]
+capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context", "github_history_witness"]
 owner_gate_reasons = []
 is_new_product_idea = false
 mandatory_context = ["AGENTS.md", "specs/factory-001a/spec.md", "specs/factory-001a/acceptance.toml", "factory/daily_run.toml"]
@@ -60,3 +60,9 @@ id = "FACTORY-DEC-003"
 subject_id = "FACTORY-001A"
 status = "OWNER_APPROVED"
 summary = "PM-DEC-007 V1 is historical; operational V2 uses active core V12 without changing PM semantics."
+
+[[owner_decisions]]
+id = "FACTORY-DEC-004"
+subject_id = "FACTORY-001A"
+status = "OWNER_APPROVED"
+summary = "Approve only five FACTORY-001A release-blocking hardening corrections; FACTORY-001B, product, trading, and capital authority remain excluded."

--- a/factory/registry.toml
+++ b/factory/registry.toml
@@ -1,0 +1,62 @@
+schema_version = 1
+
+[[epics]]
+id = "FACTORY-001"
+title = "Daily autonomous development control plane"
+goal = "Plan one bounded Owner-approved development task per day without granting write-agent or trading authority."
+status = "OWNER_APPROVED"
+approved_capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context"]
+
+[[tasks]]
+id = "FACTORY-001A"
+epic_id = "FACTORY-001"
+title = "Deterministic daily planning control plane"
+status = "REVIEW"
+priority = 1
+estimated_minutes = 90
+spec_path = "specs/factory-001a/spec.md"
+acceptance_path = "specs/factory-001a/acceptance.toml"
+capabilities = ["registry", "deterministic_preflight", "task_selection", "execution_plan", "owner_report", "daily_scheduler", "token_context"]
+owner_gate_reasons = []
+is_new_product_idea = false
+mandatory_context = ["AGENTS.md", "specs/factory-001a/spec.md", "specs/factory-001a/acceptance.toml", "factory/daily_run.toml"]
+relevant_context = ["factory/pipeline.toml", "docs/owner/CURRENT_STATE.md"]
+frozen_context = ["docs/FROZEN_CORE_V12.sha256", "docs/FROZEN_PM_DEC_007_HYBRID_V2.sha256"]
+skip_context = ["historical reviews", "ZIP snapshot contents", "trading execution code"]
+
+[[tasks]]
+id = "FACTORY-001B"
+epic_id = "FACTORY-001"
+title = "Controlled coding-agent execution"
+status = "PROPOSED"
+priority = 2
+estimated_minutes = 90
+capabilities = []
+owner_gate_reasons = ["external_service", "governance"]
+is_new_product_idea = true
+mandatory_context = []
+relevant_context = []
+frozen_context = ["docs/FROZEN_CORE_V12.sha256"]
+skip_context = ["trading execution code"]
+
+[[dependencies]]
+task_id = "FACTORY-001B"
+depends_on = "FACTORY-001A"
+
+[[owner_decisions]]
+id = "FACTORY-DEC-001"
+subject_id = "FACTORY-001A"
+status = "OWNER_APPROVED"
+summary = "Controlled V12 re-freeze and FACTORY-001A are approved."
+
+[[owner_decisions]]
+id = "FACTORY-DEC-002"
+subject_id = "FACTORY-001B"
+status = "NEEDS_OWNER"
+summary = "Automatic Codex invocation, writer execution, commit, push, PR, and merge remain unauthorized."
+
+[[owner_decisions]]
+id = "FACTORY-DEC-003"
+subject_id = "FACTORY-001A"
+status = "OWNER_APPROVED"
+summary = "PM-DEC-007 V1 is historical; operational V2 uses active core V12 without changing PM semantics."

--- a/factory/repository.py
+++ b/factory/repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -11,26 +12,35 @@ from .models import RepositoryState
 def probe_repository(root: Path) -> RepositoryState:
     try:
         completed = subprocess.run(
-            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
             cwd=root,
             check=False,
             capture_output=True,
-            text=True,
             timeout=10,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return RepositoryState(False, error=str(exc))
     if completed.returncode != 0:
-        detail = completed.stderr.strip() or f"git status exited {completed.returncode}"
+        detail = os.fsdecode(completed.stderr).strip() or f"git status exited {completed.returncode}"
         return RepositoryState(False, error=detail)
+    records = completed.stdout.split(b"\0")
+    if not records or records[-1] != b"":
+        return RepositoryState(False, error="malformed NUL-delimited git status")
+    records.pop()
     paths: list[str] = []
-    for line in completed.stdout.splitlines():
-        if len(line) < 4:
-            return RepositoryState(False, error=f"malformed git status line: {line!r}")
-        path = line[3:]
-        if " -> " in path:
-            path = path.split(" -> ", 1)[1]
-        paths.append(path.strip('"').replace("\\", "/"))
+    index = 0
+    while index < len(records):
+        entry = records[index]
+        if len(entry) < 4 or entry[2:3] != b" " or not entry[3:]:
+            return RepositoryState(False, error=f"malformed git status record: {entry!r}")
+        status = entry[:2]
+        paths.append(os.fsdecode(entry[3:]))
+        index += 1
+        if b"R" in status or b"C" in status:
+            if index >= len(records) or not records[index]:
+                return RepositoryState(False, error="rename/copy status is missing its source path")
+            paths.append(os.fsdecode(records[index]))
+            index += 1
     return RepositoryState(True, tuple(sorted(paths)))
 
 

--- a/factory/repository.py
+++ b/factory/repository.py
@@ -1,0 +1,45 @@
+"""Read-only Git working-tree probe used by deterministic preflight."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from .models import RepositoryState
+
+
+def probe_repository(root: Path) -> RepositoryState:
+    try:
+        completed = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return RepositoryState(False, error=str(exc))
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or f"git status exited {completed.returncode}"
+        return RepositoryState(False, error=detail)
+    paths: list[str] = []
+    for line in completed.stdout.splitlines():
+        if len(line) < 4:
+            return RepositoryState(False, error=f"malformed git status line: {line!r}")
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.append(path.strip('"').replace("\\", "/"))
+    return RepositoryState(True, tuple(sorted(paths)))
+
+
+def disallowed_dirty_paths(state: RepositoryState, allowed_prefixes: tuple[str, ...]) -> tuple[str, ...]:
+    if not state.known:
+        return (f"repository state unknown: {state.error}",)
+    normalized = tuple(prefix.replace("\\", "/") for prefix in allowed_prefixes)
+    return tuple(
+        path
+        for path in state.dirty_paths
+        if not any(path.startswith(prefix) for prefix in normalized)
+    )

--- a/factory/run_history.py
+++ b/factory/run_history.py
@@ -1,0 +1,169 @@
+"""Durable, immutable daily-run claims for FACTORY-001A."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from .integrity import safe_repo_path
+
+
+SCHEMA_VERSION = 1
+MOSCOW_TIMEZONE = "Europe/Moscow"
+CANONICAL_OUTPUT = "factory/artifacts"
+OWNER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$")
+
+
+class RunHistoryError(ValueError):
+    """Raised when a daily claim is conflicting, malformed, or unsafe."""
+
+
+@dataclass(frozen=True)
+class DailyClaim:
+    schema_version: int
+    date: str
+    owner_id: str
+
+
+def _validate_owner_id(owner_id: str) -> None:
+    if not isinstance(owner_id, str) or not OWNER_ID_RE.fullmatch(owner_id):
+        raise RunHistoryError("owner_id must be 1..128 safe non-whitespace characters")
+
+
+def _claim_bytes(claim: DailyClaim) -> bytes:
+    return (
+        json.dumps(
+            {
+                "date": claim.date,
+                "owner_id": claim.owner_id,
+                "schema_version": claim.schema_version,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _claim_path(root: Path, output_dir: str, run_date: date) -> Path:
+    directory = safe_repo_path(root, output_dir) / "run-history"
+    return directory / f"{run_date.isoformat()}.json"
+
+
+def load_daily_claim(path: Path, expected_date: date) -> DailyClaim:
+    """Strictly load a canonical claim; any ambiguity fails closed."""
+
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_json_object)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RunHistoryError(f"cannot load daily claim {path}: {exc}") from exc
+    if not isinstance(value, dict) or set(value) != {"schema_version", "date", "owner_id"}:
+        raise RunHistoryError(f"malformed daily claim {path}: unexpected fields")
+    schema_version = value.get("schema_version")
+    claim_date = value.get("date")
+    owner_id = value.get("owner_id")
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+        raise RunHistoryError(f"malformed daily claim {path}: unsupported schema_version")
+    if not isinstance(claim_date, str):
+        raise RunHistoryError(f"malformed daily claim {path}: date must be text")
+    try:
+        parsed_date = date.fromisoformat(claim_date)
+    except ValueError as exc:
+        raise RunHistoryError(f"malformed daily claim {path}: invalid date") from exc
+    if parsed_date != expected_date or claim_date != expected_date.isoformat():
+        raise RunHistoryError(
+            f"malformed daily claim {path}: expected date {expected_date.isoformat()}"
+        )
+    _validate_owner_id(owner_id)
+    claim = DailyClaim(SCHEMA_VERSION, claim_date, owner_id)
+    if raw != _claim_bytes(claim):
+        raise RunHistoryError(f"malformed daily claim {path}: non-canonical encoding")
+    return claim
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise RunHistoryError(f"malformed daily claim: duplicate field {key}")
+        value[key] = item
+    return value
+
+
+def _claim_daily_run_for_test(
+    root: Path, output_dir: str, run_date: date, owner_id: str
+) -> DailyClaim:
+    """Private deterministic seam for alternate test namespaces."""
+
+    _validate_owner_id(owner_id)
+    path = _claim_path(root.resolve(), output_dir, run_date)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    claim = DailyClaim(SCHEMA_VERSION, run_date.isoformat(), owner_id)
+    content = _claim_bytes(claim)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        existing = load_daily_claim(path, run_date)
+        if existing.owner_id != owner_id:
+            raise RunHistoryError(
+                f"production date {run_date.isoformat()} is already claimed by another owner"
+            )
+        return existing
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = None
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        # A partial or uncertain exclusive claim intentionally remains fail-closed.
+        raise
+    return claim
+
+
+def claim_daily_run(root: Path, run_date: date, owner_id: str) -> DailyClaim:
+    """Claim a production date only in the canonical artifact namespace."""
+
+    return _claim_daily_run_for_test(root, CANONICAL_OUTPUT, run_date, owner_id)
+
+
+def _run_date(value: str | None) -> date:
+    if value is None:
+        return datetime.now(ZoneInfo(MOSCOW_TIMEZONE)).date()
+    return date.fromisoformat(value)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--date", help="Moscow production date in YYYY-MM-DD")
+    parser.add_argument("--owner-id", required=True, help="stable invocation owner ID")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        run_date = _run_date(args.date)
+        claim = claim_daily_run(Path(args.root), run_date, args.owner_id)
+    except (OSError, RunHistoryError, ValueError) as exc:
+        print(f"FACTORY-001A CLAIM BLOCKED: {exc}", file=sys.stderr)
+        return 1
+    print(f"FACTORY-001A CLAIMED: date={claim.date} owner={claim.owner_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/factory/state_machine.py
+++ b/factory/state_machine.py
@@ -1,0 +1,45 @@
+"""Deterministic daily-run state machine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .models import RUN_STATUSES, STOP_RUN_STATUSES
+
+
+class InvalidTransition(ValueError):
+    """Raised when a run attempts a transition outside FACTORY-001A."""
+
+
+TRANSITIONS = {
+    "SCHEDULED": frozenset({"PREFLIGHT", "FAILED"}),
+    "PREFLIGHT": frozenset({"TASK_SELECTED", "NO_WORK", "BLOCKED", "NEEDS_OWNER", "FAILED"}),
+    "TASK_SELECTED": frozenset({"PLAN_CREATED", "BLOCKED", "NEEDS_OWNER", "FAILED"}),
+    "PLAN_CREATED": frozenset({"REPORT_CREATED", "FAILED"}),
+    "REPORT_CREATED": frozenset(),
+    "NO_WORK": frozenset(),
+    "BLOCKED": frozenset(),
+    "NEEDS_OWNER": frozenset(),
+    "FAILED": frozenset(),
+}
+
+
+@dataclass
+class DailyRunStateMachine:
+    status: str = "SCHEDULED"
+
+    def __post_init__(self) -> None:
+        if self.status not in RUN_STATUSES:
+            raise InvalidTransition(f"unknown initial state: {self.status}")
+
+    @property
+    def terminal(self) -> bool:
+        return self.status == "REPORT_CREATED" or self.status in STOP_RUN_STATUSES
+
+    def transition(self, target: str) -> str:
+        if target not in RUN_STATUSES:
+            raise InvalidTransition(f"unknown target state: {target}")
+        if target not in TRANSITIONS[self.status]:
+            raise InvalidTransition(f"invalid transition: {self.status} -> {target}")
+        self.status = target
+        return self.status

--- a/specs/factory-001a/acceptance.toml
+++ b/specs/factory-001a/acceptance.toml
@@ -21,7 +21,7 @@ evidence = "Tests cover the success path and reject invalid or post-terminal tra
 [[criteria]]
 id = "FACTORY-AC-004"
 title = "Only READY tasks are selectable"
-evidence = "Selection is stable by priority then ID and ignores every non-READY status."
+evidence = "Selection is stable by priority then ID, ignores every non-READY status, and a READY label alone cannot bypass Epic/capability/dependency/contract/evidence authority."
 
 [[criteria]]
 id = "FACTORY-AC-005"
@@ -31,12 +31,12 @@ evidence = "Tests block incomplete dependencies and any existing active run."
 [[criteria]]
 id = "FACTORY-AC-006"
 title = "Contracts, repository state, and evidence are required"
-evidence = "Missing spec/acceptance, disallowed repository changes, manifest mismatch, governance mismatch, or uncertain Git state blocks selection."
+evidence = "Missing spec/acceptance or referenced context evidence, disallowed repository changes, manifest mismatch, governance mismatch, or uncertain Git state blocks selection. NUL-delimited Git status parsing checks both source and destination of rename/copy records without shell splitting, so an outside-to-artifacts rename remains disallowed. Public production paths use only canonical probes."
 
 [[criteria]]
 id = "FACTORY-AC-007"
 title = "Runtime and daily task limits are enforced"
-evidence = "Tests block estimates above 90 minutes and a second selected task on the same Moscow date."
+evidence = "Tests block estimates above 90 minutes, a second local owner on the same durably claimed Moscow date, and any qualifying prior GitHub workflow run started on that Moscow date."
 
 [[criteria]]
 id = "FACTORY-AC-008"
@@ -51,14 +51,39 @@ evidence = "A gated task becomes effectively NEEDS_OWNER and no execution plan i
 [[criteria]]
 id = "FACTORY-AC-010"
 title = "Dry-run emits a plan and complete Owner Report without coding"
-evidence = "Tests verify every required report field, atomic artifacts, AI_USAGE=0, and absence of agent/network/trading calls."
+evidence = "Tests verify every required report field, atomic artifacts, AI_USAGE=0, and absence of agent/trading calls. The only network call is the separately tested read-only GitHub workflow-history witness."
 
 [[criteria]]
 id = "FACTORY-AC-011"
 title = "Scheduler and limits are immutable and safe"
-evidence = "Workflow has manual trigger, 07:00 UTC cron, read-only contents, dry-run only, no LLM secrets, and configured limits/authorities."
+evidence = "Workflow has manual trigger, 07:00 UTC cron, same-repo/ref concurrency, actions:read plus contents:read and no write permission, full-SHA actions, non-persistent checkout credentials, dry-run only, API witness before selection, optional post-run cache transport, no LLM secrets, and configured limits/authorities."
 
 [[criteria]]
 id = "FACTORY-AC-012"
 title = "Context and routing remain cost-aware guidance"
 evidence = "Plan separates MANDATORY, RELEVANT, FROZEN, and SKIP context and recommends HIGH/MEDIUM/LOW routes without implementing an LLM router."
+
+[[criteria]]
+id = "FACTORY-AC-013"
+title = "The local run lock has exclusive ownership"
+evidence = "Tests prove the public production entry owns the canonical factory/artifacts OS lock across claim and selection; public lock/claim helpers and both CLIs expose no alternate namespace; alternate namespaces remain private test seams; A continuously owns a persistent locked handle; separate-process B cannot acquire or release it; the path is never removed on normal release; B acquires afterward; content has no authority; old-holder cleanup cannot delete/release a replacement holder; and POSIX/Windows abstractions are nonblocking and fail closed."
+
+[[criteria]]
+id = "FACTORY-AC-014"
+title = "The Moscow production date is durably consumed before selection"
+evidence = "Local separate-process tests prove immutable same-date ownership and malformed-state denial. Production-shaped GitHub tests prove strict branch-only environment identity; exact GITHUB_WORKFLOW_REF repository/path/ref binding; canonical active metadata resolution to a positive numeric workflow ID; numeric-ID-only runs queries; candidate path invariance for foreign-full, foreign-short, legitimate-short, missing, and non-string representations; exact workflow_id/repository/head_branch checks; zero-prior availability; all started outcomes and schedule/manual cross-trigger consumption; previous-date/nonproduction exclusion; rerun denial before API; complete current-run witnessing; API/schema/metadata/contradiction failure; exhaustive bounded pagination; and witness-before-claim ordering. Cache state is explicitly non-authoritative."
+
+[[criteria]]
+id = "FACTORY-AC-015"
+title = "READY status cannot self-authorize work"
+evidence = "Registry and preflight tests reject a missing or non-OWNER_APPROVED Epic, capabilities outside the Epic approval, invalid/incomplete dependencies, and missing contract or referenced context evidence before selection."
+
+[[criteria]]
+id = "FACTORY-AC-016"
+title = "Production trust evidence cannot be injected by callers"
+evidence = "Public execute_daily_run, lower-level lock/claim helpers, and daily/claim CLIs accept no registry/config/output substitutions or repository_state/integrity_issues overrides. Tests reject fabricated kwargs and removed CLI flags without writing outside factory/artifacts, require production to resolve factory/registry.toml, factory/daily_run.toml, and factory/artifacts, enforce the exact singleton dirty prefix factory/artifacts/, invoke canonical Git and integrity validators, and write no execution plan when any authority input fails."
+
+[[criteria]]
+id = "FACTORY-AC-017"
+title = "Workflow dependencies are immutable and credential-minimal"
+evidence = "Tests require every actions/* occurrence in both workflows to use the Owner-reviewed full SHA, checkout persist-credentials=false, daily workflow actions:read plus contents:read only, quality workflow contents:read only, and no push/write behavior."

--- a/specs/factory-001a/acceptance.toml
+++ b/specs/factory-001a/acceptance.toml
@@ -1,0 +1,64 @@
+work_item = "FACTORY-001A"
+target_stage = "DETERMINISTIC_DRY_RUN"
+financial_semantics_changed = false
+live_trading = false
+
+[[criteria]]
+id = "FACTORY-AC-001"
+title = "Controlled core re-freeze is versioned"
+evidence = "V11 is preserved, active V12 contains the same ten paths with only the approved self_check hash changed, and PM-DEC-007 remains 9/9."
+
+[[criteria]]
+id = "FACTORY-AC-002"
+title = "Registry validates all required entity types and statuses"
+evidence = "Tests reject unknown status, duplicate ID, missing reference, path escape, dependency cycle, and multiple active runs."
+
+[[criteria]]
+id = "FACTORY-AC-003"
+title = "Daily run transitions are deterministic"
+evidence = "Tests cover the success path and reject invalid or post-terminal transitions."
+
+[[criteria]]
+id = "FACTORY-AC-004"
+title = "Only READY tasks are selectable"
+evidence = "Selection is stable by priority then ID and ignores every non-READY status."
+
+[[criteria]]
+id = "FACTORY-AC-005"
+title = "Dependencies and active runs fail closed"
+evidence = "Tests block incomplete dependencies and any existing active run."
+
+[[criteria]]
+id = "FACTORY-AC-006"
+title = "Contracts, repository state, and evidence are required"
+evidence = "Missing spec/acceptance, disallowed repository changes, manifest mismatch, governance mismatch, or uncertain Git state blocks selection."
+
+[[criteria]]
+id = "FACTORY-AC-007"
+title = "Runtime and daily task limits are enforced"
+evidence = "Tests block estimates above 90 minutes and a second selected task on the same Moscow date."
+
+[[criteria]]
+id = "FACTORY-AC-008"
+title = "Only an OWNER_APPROVED Epic can be decomposed"
+evidence = "Tests reject unapproved Epics, capability expansion, and invalid child dependencies."
+
+[[criteria]]
+id = "FACTORY-AC-009"
+title = "Owner decision categories stop planning"
+evidence = "A gated task becomes effectively NEEDS_OWNER and no execution plan is authorized."
+
+[[criteria]]
+id = "FACTORY-AC-010"
+title = "Dry-run emits a plan and complete Owner Report without coding"
+evidence = "Tests verify every required report field, atomic artifacts, AI_USAGE=0, and absence of agent/network/trading calls."
+
+[[criteria]]
+id = "FACTORY-AC-011"
+title = "Scheduler and limits are immutable and safe"
+evidence = "Workflow has manual trigger, 07:00 UTC cron, read-only contents, dry-run only, no LLM secrets, and configured limits/authorities."
+
+[[criteria]]
+id = "FACTORY-AC-012"
+title = "Context and routing remain cost-aware guidance"
+evidence = "Plan separates MANDATORY, RELEVANT, FROZEN, and SKIP context and recommends HIGH/MEDIUM/LOW routes without implementing an LLM router."

--- a/specs/factory-001a/plan.md
+++ b/specs/factory-001a/plan.md
@@ -1,0 +1,29 @@
+# FACTORY-001A — implementation plan
+
+## Architecture
+
+The control plane is a standard-library Python package under `factory/`. Registry loading, integrity checks, state transitions, preflight, decomposition, planning, and report rendering remain separate deterministic modules. The CLI composes them but contains no agent, network, or trading adapter.
+
+## Milestones
+
+1. Freeze registry and configuration contracts.
+2. Implement strict registry parsing and state transitions.
+3. Implement fail-closed integrity, repository, budget, dependency, and Owner gates.
+4. Generate an atomic JSON plan and Markdown Owner Report.
+5. Add the 07:00 UTC scheduler and Owner documents.
+6. Cover success and failure paths with focused tests.
+
+## Verification commands
+
+```bash
+python3 -m unittest tests.test_factory_daily_run tests.test_factory_freeze tests.test_install_codex_config -v
+python3 -m factory.daily_run --dry-run
+python3 scripts/self_check.py
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q factory tests/test_factory_daily_run.py tests/test_factory_freeze.py
+ruff check factory tests/test_factory_daily_run.py tests/test_factory_freeze.py
+```
+
+## Rollback
+
+Remove only FACTORY-001A package files, registry/config, workflow, focused tests, specification, and Owner documents. Preserve both frozen manifests and all trading/governance artifacts.

--- a/specs/factory-001a/plan.md
+++ b/specs/factory-001a/plan.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-The control plane is a standard-library Python package under `factory/`. Registry loading, integrity checks, state transitions, preflight, decomposition, planning, and report rendering remain separate deterministic modules. The CLI composes them but contains no agent, network, or trading adapter.
+The control plane is a standard-library Python package under `factory/`. Registry loading, GitHub workflow-history witnessing, integrity checks, state transitions, preflight, decomposition, planning, and report rendering remain separate modules. The CLI contains no agent or trading adapter; its only network boundary is the bounded read-only GitHub Actions history witness.
 
 ## Milestones
 
@@ -12,18 +12,27 @@ The control plane is a standard-library Python package under `factory/`. Registr
 4. Generate an atomic JSON plan and Markdown Owner Report.
 5. Add the 07:00 UTC scheduler and Owner documents.
 6. Cover success and failure paths with focused tests.
+7. Harden cross-platform lock ownership with a persistent path and continuously held nonblocking POSIX/Windows OS handle lock owned by the public production entry across canonical claim and selection; expose alternate lock/claim namespaces only through private test seams.
+8. Persist a strict immutable Moscow-date claim for local processes and require an environment-derived GitHub workflow-history witness before GitHub claim/selection; keep cache as optional transport only.
+9. Enforce `READY` Epic/capability/dependency/contract/evidence authority in registry validation and preflight, including both exact paths of NUL-delimited rename/copy records.
+10. Remove public and standalone-CLI registry/config/output/probe-evidence injection, enforce the exact singleton dirty allowlist and canonical artifact namespace at every public layer, and keep deterministic substitution behind private test-only boundaries.
+11. Pin all workflow actions to reviewed full SHAs and disable checkout credential persistence.
 
 ## Verification commands
 
 ```bash
-python3 -m unittest tests.test_factory_daily_run tests.test_factory_freeze tests.test_install_codex_config -v
-python3 -m factory.daily_run --dry-run
+python3 -m unittest tests.test_factory_daily_run tests.test_factory_freeze tests.test_factory_github_history tests.test_install_codex_config -v
+python3 -m factory.daily_run --dry-run --owner-id local-verification
 python3 scripts/self_check.py
 python3 -m unittest discover -s tests -v
-python3 -m compileall -q factory tests/test_factory_daily_run.py tests/test_factory_freeze.py
-ruff check factory tests/test_factory_daily_run.py tests/test_factory_freeze.py
+python3 -m compileall -q factory/configuration.py factory/daily_run.py factory/github_history.py factory/preflight.py factory/registry.py factory/repository.py factory/run_history.py tests/test_factory_daily_run.py tests/test_factory_freeze.py tests/test_factory_github_history.py
+ruff check factory/configuration.py factory/daily_run.py factory/github_history.py factory/preflight.py factory/registry.py factory/repository.py factory/run_history.py tests/test_factory_daily_run.py tests/test_factory_freeze.py tests/test_factory_github_history.py
 ```
+
+The daily workflow verification asserts exact cache restore, then the production runner's API witness/local claim/selection critical section, followed only afterward by optional cache save. The witness cross-checks trusted branch/environment identity, resolves canonical active workflow metadata to a numeric workflow ID, queries runs only by that ID and encoded short branch, ignores candidate path, exhausts bounded pagination, and fails closed on any contradiction; cache state is never an authority input.
 
 ## Rollback
 
 Remove only FACTORY-001A package files, registry/config, workflow, focused tests, specification, and Owner documents. Preserve both frozen manifests and all trading/governance artifacts.
+
+Rollback does not delete or rewrite an already-published daily claim. Claim recovery is an Owner operation outside FACTORY-001A.

--- a/specs/factory-001a/spec.md
+++ b/specs/factory-001a/spec.md
@@ -1,0 +1,82 @@
+# FACTORY-001A — Daily Autonomous Development Control Plane
+
+Status: OWNER_APPROVED
+Owner: Repository Owner
+Target stage: DETERMINISTIC_DRY_RUN
+
+## 1. Outcome
+
+A scheduled, deterministic control plane validates the development registry, selects at most one eligible `READY` task, writes an execution plan and Owner Report, and stops without invoking a coding agent or changing product code.
+
+## 2. In scope
+
+- Machine-readable EPIC, TASK, DEPENDENCY, OWNER DECISION, and RUN registry.
+- Deterministic daily-run state machine and fail-closed preflight.
+- Owner-approved Epic decomposition contract.
+- Owner decision gate for product, architecture, authority, governance, market, exchange, credential, Paper, and Live changes.
+- Dry-run CLI and daily 10:00 Europe/Moscow GitHub Actions schedule.
+- Owner control-plane documents and token-aware context classification.
+
+## 3. Out of scope
+
+- OpenAI or Codex invocation.
+- Automatic writer, commit, push, pull request, merge, or product approval.
+- Telegram or Bitget API access, credentials, orders, positions, fills, Paper, Live, or legacy execution.
+- Any change to financial semantics, risk limits, lifecycle authority, market, or exchange scope.
+
+## 4. Actors and systems
+
+| Actor/system | Responsibility | Trust boundary |
+|---|---|---|
+| Owner | Approves WHAT, WHY, scope, authority, and governance | Only actor allowed to resolve Owner gates |
+| Daily runner | Validates and plans one bounded task | Deterministic local code; no LLM or network |
+| Registry | Versioned state and dependencies | Invalid or ambiguous input stops the run |
+| GitHub Actions | Triggers the dry-run at 07:00 UTC | Read-only repository permission; no secrets |
+
+## 5. Inputs and data contracts
+
+- `factory/registry.toml` contains versioned entities with unique IDs and enumerated statuses.
+- `factory/daily_run.toml` contains immutable limits, active frozen manifests, governance hashes, and routing guidance.
+- Paths are repository-relative and cannot escape the repository root.
+- Text evidence hashes use canonical UTF-8 with LF line endings; binary artifacts use raw bytes.
+- The dry-run writes deterministic JSON and Markdown artifacts below the configured output directory.
+
+## 6. Behavioral scenarios
+
+- Given one eligible `READY` task, when preflight passes, then exactly that task is selected by `(priority, id)` and a plan/report pair is written.
+- Given no `READY` task, then the run stops as `NO_WORK` and reports no selected task.
+- Given an active run, unresolved Owner decision, invalid dependency, missing contract, dirty repository, exceeded budget, or changed frozen/governance evidence, then the run fails closed.
+- Given a proposed decomposition outside the approved Epic capability set, then no child task is created and Owner review is required.
+- Given any invalid state transition, then the state machine rejects it.
+
+## 7. Risk and execution rules
+
+`governance/risk-policy.toml` and trading execution are read-only evidence. FACTORY-001A never imports or calls Telegram, exchange, trading, order, position, fill, Paper, or Live code. `auto_merge`, product approval, Paper authority, and Live authority remain false.
+
+## 8. State machines
+
+Success path: `SCHEDULED -> PREFLIGHT -> TASK_SELECTED -> PLAN_CREATED -> REPORT_CREATED`.
+
+Stop states: `NO_WORK`, `BLOCKED`, `NEEDS_OWNER`, `FAILED`. Stop states are terminal; report serialization does not transition out of them.
+
+## 9. Non-functional requirements
+
+- Standard-library-only Python 3.12 implementation.
+- Stable ordering and serialized output for reproducibility.
+- Atomic artifact replacement.
+- At most one selected task per run and one active run in the registry.
+- No secret values, outbound network calls, subprocess-based agents, or production side effects.
+
+## 10. Research and backtest protocol
+
+Not applicable. Financial and strategy semantics are unchanged; no performance claims or backtests are introduced.
+
+## 11. Acceptance criteria
+
+Machine-readable criteria `FACTORY-AC-001` through `FACTORY-AC-012` are defined in `acceptance.toml` and traced by focused tests.
+
+## 12. Open decisions
+
+FACTORY-001B remains `NEEDS_OWNER`: automatic Codex invocation, writer execution, commit, push, PR, and merge are not authorized.
+
+The frozen evidence conflict is resolved through the Owner-approved operational PM bundle V2. Historical PM V1 and core V11 remain unchanged; active PM V2 verifies active core V12 without changing PM-DEC-007 semantics or authority.

--- a/specs/factory-001a/spec.md
+++ b/specs/factory-001a/spec.md
@@ -1,6 +1,6 @@
 # FACTORY-001A — Daily Autonomous Development Control Plane
 
-Status: OWNER_APPROVED
+Status: REVIEW
 Owner: Repository Owner
 Target stage: DETERMINISTIC_DRY_RUN
 
@@ -29,17 +29,22 @@ A scheduled, deterministic control plane validates the development registry, sel
 | Actor/system | Responsibility | Trust boundary |
 |---|---|---|
 | Owner | Approves WHAT, WHY, scope, authority, and governance | Only actor allowed to resolve Owner gates |
-| Daily runner | Validates and plans one bounded task | Deterministic local code; no LLM or network |
+| Daily runner | Validates and plans one bounded task | Deterministic standard-library code; only the GitHub Actions history witness may use network |
 | Registry | Versioned state and dependencies | Invalid or ambiguous input stops the run |
-| GitHub Actions | Triggers the dry-run at 07:00 UTC | Read-only repository permission; no secrets |
+| GitHub Actions | Triggers the dry-run at 07:00 UTC and supplies its own history witness | `contents: read` plus `actions: read`; built-in token is used only for the workflow-history GET |
 
 ## 5. Inputs and data contracts
 
 - `factory/registry.toml` contains versioned entities with unique IDs and enumerated statuses.
 - `factory/daily_run.toml` contains immutable limits, active frozen manifests, governance hashes, and routing guidance.
+- Production resolves only those exact two repository-rooted paths; neither the public API nor CLI accepts a replacement registry or configuration path. Alternate paths exist only on the explicitly private deterministic test seam.
+- `repository.allowed_dirty_prefixes` is exactly the singleton `["factory/artifacts/"]`; empty, arbitrary, duplicate, additional, or broader prefixes are invalid configuration.
+- Production lock, daily claim, plan, and report paths are fixed below `factory/artifacts/`; the public runner, public lock/claim helpers, daily CLI, and standalone claim CLI accept no alternate output namespace. Alternate namespaces exist only on explicitly private test seams. The public entry point owns the OS lock across claim and selection.
 - Paths are repository-relative and cannot escape the repository root.
 - Text evidence hashes use canonical UTF-8 with LF line endings; binary artifacts use raw bytes.
-- The dry-run writes deterministic JSON and Markdown artifacts below the configured output directory.
+- The dry-run writes deterministic JSON and Markdown artifacts below the canonical `factory/artifacts/` directory.
+- `factory/artifacts/run-history/YYYY-MM-DD.json` is the canonical immutable daily claim. It contains only schema version, Moscow production date, and stable owner ID, and is created with exclusive filesystem semantics.
+- The persistent local lock file is opened without truncation and is never unlinked, renamed, or truncated during normal release. Ownership is only the continuously held nonblocking OS lock on the live file handle: `flock` on POSIX and a one-byte `msvcrt.locking` region on Windows. File contents have no authority.
 
 ## 6. Behavioral scenarios
 
@@ -48,6 +53,14 @@ A scheduled, deterministic control plane validates the development registry, sel
 - Given an active run, unresolved Owner decision, invalid dependency, missing contract, dirty repository, exceeded budget, or changed frozen/governance evidence, then the run fails closed.
 - Given a proposed decomposition outside the approved Epic capability set, then no child task is created and Owner review is required.
 - Given any invalid state transition, then the state machine rejects it.
+- Given a `READY` task, its referenced Epic must exist and be exactly `OWNER_APPROVED`, its capabilities must be a subset of that Epic's approved capabilities, all referenced contracts/context evidence must exist, and all dependencies must be valid and complete. A direct `READY` edit bypasses none of these checks.
+- Given an existing canonical daily claim for the same owner and Moscow date, retry is allowed without rewriting the claim; a different owner or malformed claim blocks before selection. A different date has an independent claim.
+- Given a concurrent lock attempt, the losing process cannot acquire or release the winner's live handle lock; after the winner unlocks and closes, another process can acquire the persistent path. Unsupported or ambiguous acquire/release behavior fails closed.
+- Given direct public API use, the same canonical lock and daily-claim namespace applies as the CLI: alternate output namespaces are rejected, a competing public run cannot enter the critical section, same-owner retry remains idempotent, and another owner on the same date is denied.
+- Given a tracked path renamed or copied into `factory/artifacts/`, NUL-delimited Git status parsing preserves and checks both source and destination exactly, including spaces and special characters; an outside source remains disallowed and blocks before selection.
+- Given GitHub Actions execution, the runner must first witness its exact current run in the workflow-specific, branch-scoped Actions API history, must be attempt 1, and must find no prior scheduled or manually dispatched run started on the same Moscow date. Any prior started run consumes the date regardless of success, failure, cancellation, or in-progress status.
+- Given metadata or history API failure, non-2xx response, timeout, malformed/contradictory response, inactive or path-mismatched workflow metadata, unresolved numeric workflow ID, missing/inconsistent current-run witness, or truncated bounded pagination, the GitHub run stops before local claim or task selection. Candidate `path` is non-authoritative and ignored; workflow identity is the resolved numeric `workflow_id`, while repository and `head_branch` are independently required to match the trusted scope.
+- Given the public runner or dry-run CLI, configuration, registry, and output namespace always come from the exact canonical repository paths and repository/integrity evidence always comes from the canonical probes. Fabricated path, dirty-allowlist, output-namespace, or probe overrides are not accepted by the public interface.
 
 ## 7. Risk and execution rules
 
@@ -64,8 +77,18 @@ Stop states: `NO_WORK`, `BLOCKED`, `NEEDS_OWNER`, `FAILED`. Stop states are term
 - Standard-library-only Python 3.12 implementation.
 - Stable ordering and serialized output for reproducibility.
 - Atomic artifact replacement.
+- Atomic exclusive lock and daily-claim creation on Windows and Linux.
 - At most one selected task per run and one active run in the registry.
-- No secret values, outbound network calls, subprocess-based agents, or production side effects.
+- No secret values are logged or persisted. No LLM, trading, exchange, Telegram, or arbitrary network calls are allowed; the sole outbound call is the bounded read-only GitHub workflow-history witness inside GitHub Actions.
+- Every `actions/*` workflow dependency is pinned to an Owner-reviewed full commit SHA; checkout persistence of GitHub credentials is disabled.
+
+## 9.1 Lock and durable daily-history operational boundaries
+
+Outside `GITHUB_ACTIONS`, the immutable local claim is authoritative across separate local processes: the same owner may retry, another owner on the same Moscow date is denied, and malformed state fails closed. The persistent lock prevents concurrent local critical sections on one trusted filesystem. Administrative replacement of the lock path is a trusted-filesystem boundary: POSIX can give the replacement a different inode, but the old holder still unlocks only its original live handle and never deletes or releases the replacement holder.
+
+Inside GitHub Actions, the workflow-history API witness is authoritative and must succeed before the local claim and selection. Context and bearer token come only from trusted GitHub environment variables. Only branch refs are allowed: `GITHUB_REF` must be `refs/heads/<branch>`, must agree with `GITHUB_REF_NAME`, and `GITHUB_REF_TYPE`, when present, must be `branch`. `GITHUB_WORKFLOW_REF` must equal `GITHUB_REPOSITORY/.github/workflows/daily-factory-control-plane.yml@GITHUB_REF` exactly. The runner resolves `GET /repos/{repo}/actions/workflows/daily-factory-control-plane.yml`, requires strict successful metadata with a positive non-boolean numeric ID, canonical path, and active state, then queries history only through `/actions/workflows/{numeric_id}/runs` with the encoded trusted short branch. Every run must repeat that numeric `workflow_id`, repository, and `head_branch`. Candidate `path` is never parsed or used for authority. The API calls use explicit GitHub headers, bounded timeout/body/pages, strict unique-key JSON/field/timestamp parsing, and never log token, headers, or bodies. The current run must be completely witnessed before exact-ID exclusion; `GITHUB_RUN_ATTEMPT > 1` is denied before any API call. Administrative deletion or falsification of GitHub Actions history is a trusted-administrator boundary.
+
+The exact repository/ref/date cache is optional transport for the local claim only. A cache hit, miss, save, loss, or restored file does not prove workflow-history freshness and does not grant selection authority. Cache restore may precede the runner and cache save may follow a successful run; the API witness remains mandatory for both schedule and manual dispatch.
 
 ## 10. Research and backtest protocol
 
@@ -73,10 +96,12 @@ Not applicable. Financial and strategy semantics are unchanged; no performance c
 
 ## 11. Acceptance criteria
 
-Machine-readable criteria `FACTORY-AC-001` through `FACTORY-AC-012` are defined in `acceptance.toml` and traced by focused tests.
+Machine-readable criteria `FACTORY-AC-001` through `FACTORY-AC-017` are defined in `acceptance.toml` and traced by focused tests.
 
 ## 12. Open decisions
 
 FACTORY-001B remains `NEEDS_OWNER`: automatic Codex invocation, writer execution, commit, push, PR, and merge are not authorized.
 
 The frozen evidence conflict is resolved through the Owner-approved operational PM bundle V2. Historical PM V1 and core V11 remain unchanged; active PM V2 verifies active core V12 without changing PM-DEC-007 semantics or authority.
+
+FACTORY-DEC-004 authorizes only the five release-blocking FACTORY-001A hardening corrections. FACTORY-001A remains `REVIEW`; FACTORY-001B and all Product Master Spec, coding-agent, trading, credential, Paper, Live, capital, commit, push, pull-request, merge, frozen-manifest, and risk-policy authority remain unchanged and excluded.

--- a/specs/factory-001a/tasks.md
+++ b/specs/factory-001a/tasks.md
@@ -9,3 +9,10 @@
 - [x] `FACTORY-T07` Daily scheduler and immutable limits — FACTORY-AC-011.
 - [x] `FACTORY-T08` Token context and zero-AI contract — FACTORY-AC-012.
 - [x] `FACTORY-T09` Resolve the frozen PM-DEC-007 V1 parent-reference conflict through an Owner-approved V2 operational freeze.
+- [x] `FACTORY-T10` Add canonical production-entry POSIX/Windows handle-lock semantics, private-only alternate namespace seams, and adversarial cross-process/replacement/namespace tests — FACTORY-AC-013.
+- [x] `FACTORY-T11` Add durable local claims plus authoritative metadata-resolved numeric-workflow-ID GitHub history witness; retain cache only as optional transport — FACTORY-AC-014.
+- [x] `FACTORY-T12` Enforce `READY` Epic/capability/dependency/contract/evidence authority twice — FACTORY-AC-015.
+- [x] `FACTORY-T13` Remove public helper and CLI registry/config/output/trust-evidence injection, fix dirty and rename-path validation, and verify canonical production inputs, artifact namespace, and probes — FACTORY-AC-006, FACTORY-AC-016.
+- [x] `FACTORY-T14` Pin workflow actions and disable checkout credential persistence — FACTORY-AC-017.
+
+Implementation completion does not change release state: FACTORY-001A remains `REVIEW` pending all independent gates and release verification.

--- a/specs/factory-001a/tasks.md
+++ b/specs/factory-001a/tasks.md
@@ -1,0 +1,11 @@
+# FACTORY-001A — tasks
+
+- [x] `FACTORY-T01` Controlled V12 re-freeze — FACTORY-AC-001.
+- [x] `FACTORY-T02` Registry entities and validation — FACTORY-AC-002.
+- [x] `FACTORY-T03` Daily state machine — FACTORY-AC-003.
+- [x] `FACTORY-T04` Fail-closed preflight and selection — FACTORY-AC-004..007.
+- [x] `FACTORY-T05` Epic decomposition and Owner gate — FACTORY-AC-008..009.
+- [x] `FACTORY-T06` Dry-run plan and Owner Report — FACTORY-AC-010.
+- [x] `FACTORY-T07` Daily scheduler and immutable limits — FACTORY-AC-011.
+- [x] `FACTORY-T08` Token context and zero-AI contract — FACTORY-AC-012.
+- [x] `FACTORY-T09` Resolve the frozen PM-DEC-007 V1 parent-reference conflict through an Owner-approved V2 operational freeze.

--- a/tests/test_factory_daily_run.py
+++ b/tests/test_factory_daily_run.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+
+from factory.daily_run import execute_daily_run, exclusive_run_lock
+from factory.decomposition import ChildTaskDraft, OwnerDecisionRequired, decompose_epic
+from factory.models import (
+    DailyConfig,
+    Dependency,
+    Epic,
+    OwnerDecision,
+    Registry,
+    RepositoryState,
+    RunRecord,
+    Task,
+)
+from factory.preflight import run_preflight
+from factory.registry import RegistryError, load_registry, validate_registry
+from factory.state_machine import DailyRunStateMachine, InvalidTransition
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUN_DATE = date(2026, 8, 11)
+
+
+def config() -> DailyConfig:
+    return DailyConfig(
+        schema_version=1,
+        timezone="Europe/Moscow",
+        max_tasks_per_day=1,
+        max_parallel_writers=1,
+        max_correction_loops=2,
+        max_run_time_minutes=90,
+        auto_merge=False,
+        auto_product_approval=False,
+        paper_authority=False,
+        live_authority=False,
+        allow_dirty=False,
+        allowed_dirty_prefixes=("factory/artifacts/",),
+        canonicalization="UTF8_LF_TEXT_RAW_BINARY_V1",
+        active_core_manifest="docs/FROZEN_CORE_V12.sha256",
+        active_core_manifest_sha256="0" * 64,
+        pm_dec_007_manifest="docs/FROZEN_PM_DEC_007_HYBRID_V1.sha256",
+        pm_dec_007_manifest_sha256="0" * 64,
+        governance=(),
+        routing={"high": ("architecture",), "medium": ("bounded_implementation",), "low": ("summary",)},
+    )
+
+
+def task(task_id: str, status: str = "READY", priority: int = 1, estimate: int = 30) -> Task:
+    return Task(
+        id=task_id,
+        epic_id="EPIC-1",
+        title=task_id,
+        status=status,
+        priority=priority,
+        estimated_minutes=estimate,
+        spec_path=f"specs/{task_id}/spec.md",
+        acceptance_path=f"specs/{task_id}/acceptance.toml",
+        capabilities=("registry",),
+        mandatory_context=("AGENTS.md",),
+        relevant_context=("factory/pipeline.toml",),
+        frozen_context=("docs/FROZEN_CORE_V12.sha256",),
+        skip_context=("historical reviews",),
+    )
+
+
+def registry(
+    *tasks: Task,
+    dependencies: tuple[Dependency, ...] = (),
+    decisions: tuple[OwnerDecision, ...] = (),
+    runs: tuple[RunRecord, ...] = (),
+) -> Registry:
+    return Registry(
+        schema_version=1,
+        epics=(Epic("EPIC-1", "Epic", "Approved goal", "OWNER_APPROVED", ("registry",)),),
+        tasks=tuple(tasks),
+        dependencies=dependencies,
+        owner_decisions=decisions,
+        runs=runs,
+    )
+
+
+def create_contracts(root: Path, *tasks: Task) -> None:
+    for item in tasks:
+        spec = root / item.spec_path
+        acceptance = root / item.acceptance_path
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text("# spec\n", encoding="utf-8")
+        acceptance.write_text('work_item = "test"\n', encoding="utf-8")
+
+
+class StateMachineTests(unittest.TestCase):
+    def test_success_path_and_terminal_state(self) -> None:
+        machine = DailyRunStateMachine()
+        for target in ("PREFLIGHT", "TASK_SELECTED", "PLAN_CREATED", "REPORT_CREATED"):
+            machine.transition(target)
+        self.assertTrue(machine.terminal)
+        with self.assertRaises(InvalidTransition):
+            machine.transition("PREFLIGHT")
+
+    def test_invalid_transition_is_rejected(self) -> None:
+        with self.assertRaises(InvalidTransition):
+            DailyRunStateMachine().transition("PLAN_CREATED")
+
+
+class RegistryValidationTests(unittest.TestCase):
+    def test_unknown_status_and_duplicate_id_are_rejected(self) -> None:
+        with self.assertRaisesRegex(RegistryError, "unknown Task status"):
+            validate_registry(registry(task("T-1", "UNKNOWN")))
+        with self.assertRaisesRegex(RegistryError, "duplicate Task"):
+            validate_registry(registry(task("T-1"), task("T-1")))
+
+    def test_missing_reference_cycle_and_multiple_active_runs_are_rejected(self) -> None:
+        with self.assertRaisesRegex(RegistryError, "missing task"):
+            validate_registry(registry(task("T-1"), dependencies=(Dependency("T-1", "MISSING"),)))
+        one = task("T-1")
+        two = task("T-2")
+        with self.assertRaisesRegex(RegistryError, "dependency cycle"):
+            validate_registry(
+                registry(one, two, dependencies=(Dependency("T-1", "T-2"), Dependency("T-2", "T-1")))
+            )
+        runs = (
+            RunRecord("R-1", "PREFLIGHT", RUN_DATE.isoformat()),
+            RunRecord("R-2", "PLAN_CREATED", RUN_DATE.isoformat()),
+        )
+        with self.assertRaisesRegex(RegistryError, "more than one active run"):
+            validate_registry(registry(one, runs=runs))
+
+    def test_registry_path_escape_is_rejected(self) -> None:
+        content = """
+schema_version = 1
+[[epics]]
+id = "E"
+title = "E"
+goal = "G"
+status = "OWNER_APPROVED"
+approved_capabilities = []
+[[tasks]]
+id = "T"
+epic_id = "E"
+title = "T"
+status = "READY"
+priority = 1
+estimated_minutes = 1
+spec_path = "../outside.md"
+acceptance_path = "acceptance.toml"
+"""
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "registry.toml"
+            path.write_text(content, encoding="utf-8")
+            with self.assertRaisesRegex(RegistryError, "repository-relative"):
+                load_registry(path)
+
+
+class PreflightTests(unittest.TestCase):
+    def test_ready_selection_is_stable_and_only_ready_is_selected(self) -> None:
+        proposed = task("T-0", "PROPOSED", priority=0)
+        second = task("T-2", priority=2)
+        first = task("T-1", priority=1)
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_contracts(root, first, second)
+            result = run_preflight(
+                registry(proposed, second, first),
+                config(),
+                root,
+                RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+        self.assertEqual("TASK_SELECTED", result.status)
+        self.assertEqual("T-1", result.selected_task.id)
+
+    def test_dependencies_active_run_and_needs_owner_block(self) -> None:
+        ready = task("T-1")
+        parent = task("T-0", "REVIEW")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_contracts(root, ready)
+            blocked = run_preflight(
+                registry(parent, ready, dependencies=(Dependency("T-1", "T-0"),)),
+                config(),
+                root,
+                RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+            active = run_preflight(
+                registry(ready, runs=(RunRecord("R", "PREFLIGHT", RUN_DATE.isoformat()),)),
+                config(),
+                root,
+                RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+            owner = run_preflight(
+                registry(
+                    ready,
+                    decisions=(OwnerDecision("D", "T-1", "NEEDS_OWNER", "Owner choice"),),
+                ),
+                config(),
+                root,
+                RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+        self.assertEqual("BLOCKED", blocked.status)
+        self.assertEqual("BLOCKED", active.status)
+        self.assertEqual("NEEDS_OWNER", owner.status)
+
+    def test_contract_repository_integrity_and_budgets_fail_closed(self) -> None:
+        ready = task("T-1")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            missing = run_preflight(
+                registry(ready), config(), root, RUN_DATE,
+                repository_state=RepositoryState(True), integrity_issues=(),
+            )
+            create_contracts(root, ready)
+            dirty = run_preflight(
+                registry(ready), config(), root, RUN_DATE,
+                repository_state=RepositoryState(True, ("unexpected.txt",)), integrity_issues=(),
+            )
+            uncertain = run_preflight(
+                registry(ready), config(), root, RUN_DATE,
+                repository_state=RepositoryState(False, error="git unavailable"), integrity_issues=(),
+            )
+            evidence = run_preflight(
+                registry(ready), config(), root, RUN_DATE,
+                repository_state=RepositoryState(True), integrity_issues=("frozen mismatch",),
+            )
+            runtime = run_preflight(
+                registry(replace(ready, estimated_minutes=91)), config(), root, RUN_DATE,
+                repository_state=RepositoryState(True), integrity_issues=(),
+            )
+            daily = run_preflight(
+                registry(ready, runs=(RunRecord("R", "REPORT_CREATED", RUN_DATE.isoformat(), "T-1"),)),
+                config(), root, RUN_DATE,
+                repository_state=RepositoryState(True), integrity_issues=(),
+            )
+        for result in (missing, dirty, uncertain, evidence, runtime, daily):
+            self.assertEqual("BLOCKED", result.status)
+
+    def test_no_ready_task_returns_no_work(self) -> None:
+        result = run_preflight(
+            registry(task("T-1", "PROPOSED")), config(), Path.cwd(), RUN_DATE,
+            repository_state=RepositoryState(True), integrity_issues=(),
+        )
+        self.assertEqual("NO_WORK", result.status)
+
+    def test_ready_task_owner_gate_returns_needs_owner(self) -> None:
+        gated = replace(task("T-1"), owner_gate_reasons=("external_service",))
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_contracts(root, gated)
+            result = run_preflight(
+                registry(gated), config(), root, RUN_DATE,
+                repository_state=RepositoryState(True), integrity_issues=(),
+            )
+        self.assertEqual("NEEDS_OWNER", result.status)
+        self.assertIsNone(result.selected_task)
+
+
+class DecompositionTests(unittest.TestCase):
+    def test_only_approved_epic_and_capabilities_are_allowed(self) -> None:
+        base = registry()
+        draft = ChildTaskDraft("T-1", "Child", "READY", 1, 30, "Approved goal", ("registry",))
+        created, dependencies = decompose_epic(base, "EPIC-1", (draft,))
+        self.assertEqual(("T-1",), tuple(item.id for item in created))
+        self.assertEqual((), dependencies)
+
+        unapproved = replace(base, epics=(replace(base.epics[0], status="PROPOSED"),))
+        with self.assertRaises(OwnerDecisionRequired):
+            decompose_epic(unapproved, "EPIC-1", (draft,))
+        expanded = replace(draft, capabilities=("registry", "new_market"))
+        with self.assertRaises(OwnerDecisionRequired):
+            decompose_epic(base, "EPIC-1", (expanded,))
+        changed_goal = replace(draft, parent_goal="Different goal")
+        with self.assertRaises(OwnerDecisionRequired):
+            decompose_epic(base, "EPIC-1", (changed_goal,))
+
+    def test_new_product_idea_can_only_be_proposed(self) -> None:
+        draft = ChildTaskDraft(
+            "T-1", "Idea", "READY", 1, 30, "Approved goal", (), is_new_product_idea=True
+        )
+        with self.assertRaises(OwnerDecisionRequired):
+            decompose_epic(registry(), "EPIC-1", (draft,))
+
+
+class DryRunIntegrationTests(unittest.TestCase):
+    def test_dry_run_writes_deterministic_plan_and_complete_report(self) -> None:
+        registry_text = """
+schema_version = 1
+[[epics]]
+id = "EPIC-1"
+title = "Epic"
+goal = "Approved goal"
+status = "OWNER_APPROVED"
+approved_capabilities = ["registry"]
+[[tasks]]
+id = "T-1"
+epic_id = "EPIC-1"
+title = "Ready task"
+status = "READY"
+priority = 1
+estimated_minutes = 30
+spec_path = "specs/T-1/spec.md"
+acceptance_path = "specs/T-1/acceptance.toml"
+capabilities = ["registry"]
+owner_gate_reasons = []
+is_new_product_idea = false
+mandatory_context = ["AGENTS.md"]
+relevant_context = ["factory/pipeline.toml"]
+frozen_context = ["docs/FROZEN_CORE_V12.sha256"]
+skip_context = ["historical reviews"]
+"""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "factory").mkdir()
+            (root / "factory/daily_run.toml").write_text(
+                (ROOT / "factory/daily_run.toml").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            (root / "factory/registry.toml").write_text(registry_text, encoding="utf-8")
+            (root / "factory/pipeline.toml").write_text(
+                (ROOT / "factory/pipeline.toml").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            ready = task("T-1")
+            create_contracts(root, ready)
+            first = execute_daily_run(
+                root,
+                run_date=RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+            plan_bytes = (root / first.plan_path).read_bytes()
+            report_bytes = (root / first.report_path).read_bytes()
+            second = execute_daily_run(
+                root,
+                run_date=RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+            self.assertEqual(plan_bytes, (root / second.plan_path).read_bytes())
+            self.assertEqual(report_bytes, (root / second.report_path).read_bytes())
+            report = report_bytes.decode("utf-8")
+        self.assertEqual("REPORT_CREATED", first.status)
+        self.assertEqual("T-1", first.selected_task_id)
+        for heading in (
+            "DATE", "RUN STATUS", "EPIC", "SELECTED TASK", "WHY THIS TASK", "DEPENDENCIES",
+            "WHAT WOULD RUN NEXT", "OWNER DECISIONS", "BLOCKERS", "TOKEN PLAN", "AI_USAGE",
+            "NEXT ACTION",
+        ):
+            self.assertIn(f"## {heading}", report)
+        self.assertIn("## AI_USAGE\n0", report)
+        self.assertIn("FACTORY-001A will not invoke a coding agent", report)
+
+    def test_exclusive_lock_blocks_second_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with exclusive_run_lock(root, "factory/artifacts"):
+                with self.assertRaises(FileExistsError):
+                    with exclusive_run_lock(root, "factory/artifacts"):
+                        self.fail("nested lock unexpectedly acquired")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factory_daily_run.py
+++ b/tests/test_factory_daily_run.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
 
+import os
 import tempfile
+import subprocess
+import sys
 import unittest
 from dataclasses import replace
 from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
-from factory.daily_run import execute_daily_run, exclusive_run_lock
+from factory.configuration import ConfigurationError, load_daily_config
+from factory.daily_run import (
+    RunLockError,
+    _acquire_platform_lock,
+    _execute_daily_run_for_test,
+    _release_platform_lock,
+    execute_daily_run,
+    exclusive_run_lock,
+)
 from factory.decomposition import ChildTaskDraft, OwnerDecisionRequired, decompose_epic
+from factory.integrity import canonical_sha256, verify_integrity
 from factory.models import (
     DailyConfig,
     Dependency,
@@ -18,13 +31,58 @@ from factory.models import (
     RunRecord,
     Task,
 )
-from factory.preflight import run_preflight
+from factory.preflight import _run_preflight_for_test
 from factory.registry import RegistryError, load_registry, validate_registry
+from factory.repository import disallowed_dirty_paths, probe_repository
+from factory.run_history import RunHistoryError, claim_daily_run, load_daily_claim
 from factory.state_machine import DailyRunStateMachine, InvalidTransition
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RUN_DATE = date(2026, 8, 11)
+run_preflight = _run_preflight_for_test
+
+LOCK_ATTEMPT_SCRIPT = """
+import sys
+from pathlib import Path
+from factory.daily_run import exclusive_run_lock
+try:
+    with exclusive_run_lock(Path(sys.argv[1])):
+        pass
+except FileExistsError:
+    raise SystemExit(3)
+"""
+
+LOCK_RELEASE_WITHOUT_OWNERSHIP_SCRIPT = """
+import os
+import sys
+from pathlib import Path
+from factory.daily_run import _release_platform_lock
+path = Path(sys.argv[1]) / "factory/artifacts/.daily-run.lock"
+descriptor = os.open(path, os.O_RDWR)
+try:
+    try:
+        _release_platform_lock(descriptor)
+    except OSError:
+        pass
+finally:
+    os.close(descriptor)
+"""
+
+PUBLIC_RUN_ATTEMPT_SCRIPT = """
+import sys
+from datetime import date
+from pathlib import Path
+from factory.daily_run import execute_daily_run
+try:
+    execute_daily_run(
+        Path(sys.argv[1]),
+        owner_id="competing-public-run",
+        run_date=date.fromisoformat(sys.argv[2]),
+    )
+except FileExistsError:
+    raise SystemExit(3)
+"""
 
 
 def config() -> DailyConfig:
@@ -44,7 +102,7 @@ def config() -> DailyConfig:
         canonicalization="UTF8_LF_TEXT_RAW_BINARY_V1",
         active_core_manifest="docs/FROZEN_CORE_V12.sha256",
         active_core_manifest_sha256="0" * 64,
-        pm_dec_007_manifest="docs/FROZEN_PM_DEC_007_HYBRID_V1.sha256",
+        pm_dec_007_manifest="docs/FROZEN_PM_DEC_007_HYBRID_V2.sha256",
         pm_dec_007_manifest_sha256="0" * 64,
         governance=(),
         routing={"high": ("architecture",), "medium": ("bounded_implementation",), "low": ("summary",)},
@@ -92,6 +150,128 @@ def create_contracts(root: Path, *tasks: Task) -> None:
         spec.parent.mkdir(parents=True, exist_ok=True)
         spec.write_text("# spec\n", encoding="utf-8")
         acceptance.write_text('work_item = "test"\n', encoding="utf-8")
+        for relative in item.mandatory_context + item.relevant_context + item.frozen_context:
+            evidence = root / relative
+            evidence.parent.mkdir(parents=True, exist_ok=True)
+            if not evidence.exists():
+                evidence.write_text("test evidence\n", encoding="utf-8")
+
+
+def create_production_fixture(root: Path) -> None:
+    (root / "factory").mkdir()
+    (root / "evidence").mkdir()
+    (root / "governance").mkdir()
+    (root / "evidence/core.txt").write_text("core\n", encoding="utf-8")
+    (root / "evidence/pm.txt").write_text("pm\n", encoding="utf-8")
+    (root / "governance/approval-policy.toml").write_text(
+        'schema_version = 1\n', encoding="utf-8"
+    )
+    core_digest = canonical_sha256(root / "evidence/core.txt")
+    pm_digest = canonical_sha256(root / "evidence/pm.txt")
+    (root / "docs").mkdir()
+    (root / "docs/core.sha256").write_text(
+        f"{core_digest}  *evidence/core.txt\n", encoding="utf-8"
+    )
+    (root / "docs/pm.sha256").write_text(
+        f"{pm_digest}  *evidence/pm.txt\n", encoding="utf-8"
+    )
+    governance_digest = canonical_sha256(root / "governance/approval-policy.toml")
+    core_manifest_digest = canonical_sha256(root / "docs/core.sha256")
+    pm_manifest_digest = canonical_sha256(root / "docs/pm.sha256")
+    (root / "factory/daily_run.toml").write_text(
+        f'''schema_version = 1
+timezone = "Europe/Moscow"
+max_tasks_per_day = 1
+max_parallel_writers = 1
+max_correction_loops = 2
+max_run_time_minutes = 90
+auto_merge = false
+auto_product_approval = false
+paper_authority = false
+live_authority = false
+
+[repository]
+allow_dirty = false
+allowed_dirty_prefixes = ["factory/artifacts/"]
+
+[integrity]
+canonicalization = "UTF8_LF_TEXT_RAW_BINARY_V1"
+active_core_manifest = "docs/core.sha256"
+active_core_manifest_sha256 = "{core_manifest_digest}"
+pm_dec_007_manifest = "docs/pm.sha256"
+pm_dec_007_manifest_sha256 = "{pm_manifest_digest}"
+
+[[integrity.governance]]
+path = "governance/approval-policy.toml"
+sha256 = "{governance_digest}"
+
+[routing]
+high = ["architecture"]
+medium = ["bounded_implementation"]
+low = ["summary"]
+''',
+        encoding="utf-8",
+    )
+    (root / "factory/registry.toml").write_text("schema_version = 1\n", encoding="utf-8")
+    (root / "factory/pipeline.toml").write_text("schema_version = 1\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True, timeout=10)
+    subprocess.run(["git", "add", "."], cwd=root, check=True, timeout=10)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=FACTORY Test",
+            "-c",
+            "user.email=factory@example.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ],
+        cwd=root,
+        check=True,
+        timeout=10,
+    )
+
+
+def create_injected_authority_fixture(root: Path) -> tuple[Path, Path]:
+    injected_root = root / "factory/artifacts/injected-authority"
+    injected_root.mkdir(parents=True)
+    (injected_root / "spec.md").write_text("# injected spec\n", encoding="utf-8")
+    (injected_root / "acceptance.toml").write_text(
+        'work_item = "INJECTED"\n', encoding="utf-8"
+    )
+    registry_path = injected_root / "registry.toml"
+    registry_path.write_text(
+        '''schema_version = 1
+[[epics]]
+id = "INJECTED-EPIC"
+title = "Injected Epic"
+goal = "Create an unauthorized plan"
+status = "OWNER_APPROVED"
+approved_capabilities = ["registry"]
+[[tasks]]
+id = "INJECTED-TASK"
+epic_id = "INJECTED-EPIC"
+title = "Injected READY task"
+status = "READY"
+priority = 1
+estimated_minutes = 1
+spec_path = "factory/artifacts/injected-authority/spec.md"
+acceptance_path = "factory/artifacts/injected-authority/acceptance.toml"
+capabilities = ["registry"]
+owner_gate_reasons = []
+is_new_product_idea = false
+mandatory_context = []
+relevant_context = []
+frozen_context = []
+skip_context = []
+''',
+        encoding="utf-8",
+    )
+    config_path = injected_root / "daily_run.toml"
+    config_path.write_bytes((root / "factory/daily_run.toml").read_bytes())
+    return registry_path, config_path
 
 
 class StateMachineTests(unittest.TestCase):
@@ -155,6 +335,35 @@ acceptance_path = "acceptance.toml"
             path.write_text(content, encoding="utf-8")
             with self.assertRaisesRegex(RegistryError, "repository-relative"):
                 load_registry(path)
+
+    def test_ready_requires_existing_owner_approved_epic_and_capability_subset(self) -> None:
+        ready = task("T-1")
+        unapproved = replace(
+            registry(ready),
+            epics=(Epic("EPIC-1", "Epic", "Approved goal", "READY", ("registry",)),),
+        )
+        with self.assertRaisesRegex(RegistryError, "requires OWNER_APPROVED Epic"):
+            validate_registry(unapproved)
+
+        expanded = replace(ready, capabilities=("registry", "new_capability"))
+        with self.assertRaisesRegex(RegistryError, "exceeds Epic"):
+            validate_registry(registry(expanded))
+
+        missing = replace(registry(ready), epics=())
+        with self.assertRaisesRegex(RegistryError, "references missing Epic"):
+            validate_registry(missing)
+
+    def test_registry_validation_requires_ready_contracts_and_context_evidence(self) -> None:
+        ready = task("T-1")
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(RegistryError, "missing spec"):
+                validate_registry(registry(ready), root=root)
+            create_contracts(root, ready)
+            validate_registry(registry(ready), root=root)
+            (root / "AGENTS.md").unlink()
+            with self.assertRaisesRegex(RegistryError, "missing mandatory_context"):
+                validate_registry(registry(ready), root=root)
 
 
 class PreflightTests(unittest.TestCase):
@@ -265,6 +474,43 @@ class PreflightTests(unittest.TestCase):
         self.assertEqual("NEEDS_OWNER", result.status)
         self.assertIsNone(result.selected_task)
 
+    def test_direct_ready_cannot_bypass_epic_authority_or_context_evidence(self) -> None:
+        ready = task("T-1")
+        cases = (
+            replace(
+                registry(ready),
+                epics=(Epic("EPIC-1", "Epic", "Approved goal", "READY", ("registry",)),),
+            ),
+            registry(replace(ready, capabilities=("registry", "extra"))),
+            replace(registry(ready), epics=()),
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_contracts(root, ready)
+            for invalid in cases:
+                result = run_preflight(
+                    invalid,
+                    config(),
+                    root,
+                    RUN_DATE,
+                    repository_state=RepositoryState(True),
+                    integrity_issues=(),
+                )
+                self.assertEqual("BLOCKED", result.status)
+                self.assertIsNone(result.selected_task)
+
+            (root / "AGENTS.md").unlink()
+            missing_evidence = run_preflight(
+                registry(ready),
+                config(),
+                root,
+                RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+        self.assertEqual("BLOCKED", missing_evidence.status)
+        self.assertIn("missing mandatory_context", missing_evidence.blockers[0])
+
 
 class DecompositionTests(unittest.TestCase):
     def test_only_approved_epic_and_capabilities_are_allowed(self) -> None:
@@ -331,7 +577,7 @@ skip_context = ["historical reviews"]
             )
             ready = task("T-1")
             create_contracts(root, ready)
-            first = execute_daily_run(
+            first = _execute_daily_run_for_test(
                 root,
                 run_date=RUN_DATE,
                 repository_state=RepositoryState(True),
@@ -339,7 +585,7 @@ skip_context = ["historical reviews"]
             )
             plan_bytes = (root / first.plan_path).read_bytes()
             report_bytes = (root / first.report_path).read_bytes()
-            second = execute_daily_run(
+            second = _execute_daily_run_for_test(
                 root,
                 run_date=RUN_DATE,
                 repository_state=RepositoryState(True),
@@ -359,13 +605,490 @@ skip_context = ["historical reviews"]
         self.assertIn("## AI_USAGE\n0", report)
         self.assertIn("FACTORY-001A will not invoke a coding agent", report)
 
-    def test_exclusive_lock_blocks_second_run(self) -> None:
+    def _invoke_lock_process(self, root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-c", LOCK_ATTEMPT_SCRIPT, str(root)],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_persistent_handle_lock_blocks_and_cannot_be_released_by_competitor(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
-            with exclusive_run_lock(root, "factory/artifacts"):
-                with self.assertRaises(FileExistsError):
-                    with exclusive_run_lock(root, "factory/artifacts"):
-                        self.fail("nested lock unexpectedly acquired")
+            lock_path = root / "factory/artifacts/.daily-run.lock"
+            with exclusive_run_lock(root):
+                blocked = self._invoke_lock_process(root)
+                self.assertEqual(3, blocked.returncode, blocked.stderr)
+                release = subprocess.run(
+                    [sys.executable, "-c", LOCK_RELEASE_WITHOUT_OWNERSHIP_SCRIPT, str(root)],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(0, release.returncode, release.stderr)
+                still_blocked = self._invoke_lock_process(root)
+                self.assertEqual(3, still_blocked.returncode, still_blocked.stderr)
+                self.assertTrue(lock_path.is_file())
+            self.assertTrue(lock_path.is_file())
+            acquired_after_release = self._invoke_lock_process(root)
+            self.assertEqual(0, acquired_after_release.returncode, acquired_after_release.stderr)
+            self.assertTrue(lock_path.is_file())
+
+    def test_lock_contents_have_no_authority_and_normal_release_never_unlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            lock_path = root / "factory/artifacts/.daily-run.lock"
+            with exclusive_run_lock(root):
+                mutation_permitted = True
+                try:
+                    lock_path.write_bytes(b"administrative content mutation")
+                except PermissionError:
+                    mutation_permitted = False
+                blocked = self._invoke_lock_process(root)
+                self.assertEqual(3, blocked.returncode, blocked.stderr)
+            self.assertTrue(lock_path.is_file())
+            if mutation_permitted:
+                self.assertEqual(b"administrative content mutation", lock_path.read_bytes())
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permits administrative path replacement")
+    def test_old_holder_cleanup_cannot_release_or_delete_replacement_holder(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            lock_path = root / "factory/artifacts/.daily-run.lock"
+            first = exclusive_run_lock(root)
+            first.__enter__()
+            replacement = lock_path.with_suffix(".replacement")
+            replacement.write_bytes(b"replacement")
+            os.replace(replacement, lock_path)
+            second = exclusive_run_lock(root)
+            second.__enter__()
+            try:
+                first.__exit__(None, None, None)
+                blocked = self._invoke_lock_process(root)
+                self.assertEqual(3, blocked.returncode, blocked.stderr)
+                self.assertTrue(lock_path.is_file())
+            finally:
+                second.__exit__(None, None, None)
+            self.assertEqual(0, self._invoke_lock_process(root).returncode)
+
+    def test_posix_and_windows_lock_abstractions_are_nonblocking_and_non_destructive(self) -> None:
+        class FakePosix:
+            LOCK_EX = 1
+            LOCK_NB = 2
+            LOCK_UN = 4
+
+            def __init__(self) -> None:
+                self.calls: list[tuple[int, int]] = []
+
+            def flock(self, descriptor: int, operation: int) -> None:
+                self.calls.append((descriptor, operation))
+
+        class FakeWindows:
+            LK_NBLCK = 1
+            LK_UNLCK = 2
+
+            def __init__(self) -> None:
+                self.calls: list[tuple[int, int, int]] = []
+
+            def locking(self, descriptor: int, operation: int, count: int) -> None:
+                self.calls.append((descriptor, operation, count))
+
+        posix = FakePosix()
+        _acquire_platform_lock(7, platform="posix", posix_module=posix)
+        _release_platform_lock(7, platform="posix", posix_module=posix)
+        self.assertEqual([(7, 3), (7, 4)], posix.calls)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "lock"
+            descriptor = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+            windows = FakeWindows()
+            try:
+                _acquire_platform_lock(descriptor, platform="nt", windows_module=windows)
+                _release_platform_lock(descriptor, platform="nt", windows_module=windows)
+                self.assertEqual(b"\0", path.read_bytes())
+            finally:
+                os.close(descriptor)
+            path.write_bytes(b"existing")
+            descriptor = os.open(path, os.O_RDWR)
+            try:
+                _acquire_platform_lock(descriptor, platform="nt", windows_module=windows)
+                _release_platform_lock(descriptor, platform="nt", windows_module=windows)
+            finally:
+                os.close(descriptor)
+            self.assertEqual(b"existing", path.read_bytes())
+            self.assertEqual(4, len(windows.calls))
+
+        with self.assertRaises(RunLockError):
+            _acquire_platform_lock(7, platform="unsupported")
+
+
+class ProductionTrustBoundaryTests(unittest.TestCase):
+    def test_public_function_rejects_fabricated_probe_overrides(self) -> None:
+        with self.assertRaises(TypeError):
+            execute_daily_run(
+                Path.cwd(),
+                owner_id="owner-a",
+                run_date=RUN_DATE,
+                repository_state=RepositoryState(True),
+                integrity_issues=(),
+            )
+
+    def test_lower_level_public_helpers_reject_output_namespace_substitution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaises(TypeError):
+                claim_daily_run(
+                    root,
+                    RUN_DATE,
+                    "injected-claim-owner",
+                    output_dir="governance",
+                )
+            with self.assertRaises(TypeError):
+                with exclusive_run_lock(root, output_dir="governance"):
+                    self.fail("noncanonical lock unexpectedly acquired")
+            self.assertFalse((root / "governance").exists())
+
+    def test_public_api_rejects_registry_and_config_substitution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            registry_path, config_path = create_injected_authority_fixture(root)
+            injected = load_registry(registry_path, root=root)
+            self.assertEqual("READY", injected.tasks[0].status)
+            load_daily_config(config_path)
+
+            for keyword, relative in (
+                ("registry_path", registry_path.relative_to(root).as_posix()),
+                ("config_path", config_path.relative_to(root).as_posix()),
+                ("output_dir", "factory/artifacts/alternate-a"),
+                ("output_dir", "factory/artifacts/alternate-b"),
+            ):
+                with self.subTest(keyword=keyword, relative=relative), self.assertRaises(TypeError):
+                    execute_daily_run(
+                        root,
+                        owner_id="public-substitution",
+                        run_date=RUN_DATE,
+                        **{keyword: relative},
+                    )
+
+            self.assertFalse(
+                (root / "factory/artifacts/2026-08-11-execution-plan.json").exists()
+            )
+
+    def test_cli_rejects_registry_and_config_substitution(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            registry_path, config_path = create_injected_authority_fixture(root)
+            for flag, value in (
+                ("--registry", registry_path.relative_to(root).as_posix()),
+                ("--config", config_path.relative_to(root).as_posix()),
+                ("--output-dir", "factory/artifacts/alternate"),
+            ):
+                attempted = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "factory.daily_run",
+                        "--dry-run",
+                        "--root",
+                        str(root),
+                        "--owner-id",
+                        "cli-substitution",
+                        flag,
+                        value,
+                    ],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                with self.subTest(flag=flag):
+                    self.assertEqual(2, attempted.returncode, attempted.stderr)
+                    self.assertIn(f"unrecognized arguments: {flag}", attempted.stderr)
+            self.assertFalse(
+                (root / "factory/artifacts/2026-08-11-execution-plan.json").exists()
+            )
+
+    def test_public_entry_owns_canonical_lock_and_claim_namespace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            claim_path = root / "factory/artifacts/run-history/2026-08-11.json"
+            with exclusive_run_lock(root):
+                blocked = subprocess.run(
+                    [sys.executable, "-c", PUBLIC_RUN_ATTEMPT_SCRIPT, str(root), RUN_DATE.isoformat()],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                self.assertEqual(3, blocked.returncode, blocked.stderr)
+                self.assertFalse(claim_path.exists())
+
+            with patch("factory.daily_run.github_actions_enabled", return_value=False):
+                first = execute_daily_run(root, owner_id="canonical-owner", run_date=RUN_DATE)
+                retry = execute_daily_run(root, owner_id="canonical-owner", run_date=RUN_DATE)
+                with self.assertRaisesRegex(RunHistoryError, "already claimed"):
+                    execute_daily_run(root, owner_id="different-owner", run_date=RUN_DATE)
+
+            self.assertEqual("NO_WORK", first.status)
+            self.assertEqual("NO_WORK", retry.status)
+            self.assertEqual("canonical-owner", load_daily_claim(claim_path, RUN_DATE).owner_id)
+            self.assertFalse((root / "factory/artifacts/alternate-a").exists())
+            self.assertFalse((root / "factory/artifacts/alternate-b").exists())
+
+    def test_production_cli_uses_canonical_lock_claim_and_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            environment = os.environ.copy()
+            environment.pop("GITHUB_ACTIONS", None)
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "factory.daily_run",
+                    "--dry-run",
+                    "--root",
+                    str(root),
+                    "--date",
+                    RUN_DATE.isoformat(),
+                    "--owner-id",
+                    "canonical-cli-owner",
+                ],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            claim_path = root / "factory/artifacts/run-history/2026-08-11.json"
+            self.assertEqual(
+                "canonical-cli-owner", load_daily_claim(claim_path, RUN_DATE).owner_id
+            )
+            self.assertTrue((root / "factory/artifacts/2026-08-11-owner-report.md").is_file())
+            self.assertFalse((root / "governance/run-history").exists())
+
+    def test_dirty_allowlist_cannot_be_empty_arbitrary_multiple_or_self_expanded(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            injected_registry, _ = create_injected_authority_fixture(root)
+            (root / "factory/registry.toml").write_bytes(injected_registry.read_bytes())
+            config_path = root / "factory/daily_run.toml"
+            original = config_path.read_text(encoding="utf-8")
+            for policy in (
+                "[]",
+                '["factory/"]',
+                '["factory/artifacts/", "factory/"]',
+                '["factory/artifacts/", "factory/artifacts/injected-authority/"]',
+            ):
+                config_path.write_text(
+                    original.replace('["factory/artifacts/"]', policy), encoding="utf-8"
+                )
+                with self.subTest(policy=policy), self.assertRaisesRegex(
+                    ConfigurationError, "must remain exactly"
+                ):
+                    load_daily_config(config_path)
+
+            config_path.write_text(
+                original.replace(
+                    '["factory/artifacts/"]', '["factory/artifacts/", "factory/"]'
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch("factory.daily_run.github_actions_enabled", return_value=False),
+                self.assertRaisesRegex(ConfigurationError, "must remain exactly"),
+            ):
+                execute_daily_run(
+                    root,
+                    owner_id="expanded-dirty-policy",
+                    run_date=RUN_DATE,
+                )
+            self.assertFalse(
+                (root / "factory/artifacts/2026-08-11-execution-plan.json").exists()
+            )
+
+    def test_production_path_calls_canonical_validators_and_blocks_without_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            registry_before = (root / "factory/registry.toml").read_bytes()
+            with (
+                patch("factory.daily_run.github_actions_enabled", return_value=False),
+                patch("factory.daily_run.probe_repository", wraps=probe_repository) as repo_probe,
+                patch("factory.daily_run.verify_integrity", wraps=verify_integrity) as integrity_probe,
+            ):
+                first = execute_daily_run(
+                    root,
+                    owner_id="workflow-100:1",
+                    run_date=RUN_DATE,
+                )
+            self.assertEqual("NO_WORK", first.status)
+            repo_probe.assert_called_once_with(root.resolve())
+            self.assertEqual(1, integrity_probe.call_count)
+
+            (root / "evidence/core.txt").write_text("tampered\n", encoding="utf-8")
+            with patch("factory.daily_run.github_actions_enabled", return_value=False):
+                blocked = execute_daily_run(
+                    root,
+                    owner_id="workflow-101:1",
+                    run_date=date(2026, 8, 12),
+                )
+            self.assertEqual("BLOCKED", blocked.status)
+            self.assertEqual("", blocked.selected_task_id)
+            self.assertFalse(
+                (root / "factory/artifacts/2026-08-12-execution-plan.json").exists()
+            )
+            self.assertEqual(registry_before, (root / "factory/registry.toml").read_bytes())
+
+
+class RepositoryProbeTests(unittest.TestCase):
+    def test_outside_to_artifacts_rename_checks_source_and_blocks_production_selection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            create_production_fixture(root)
+            injected_registry, _ = create_injected_authority_fixture(root)
+            (root / "factory/registry.toml").write_bytes(injected_registry.read_bytes())
+            source = "ordinary file [source].txt"
+            destination = "factory/artifacts/renamed file [destination].txt"
+            (root / source).write_text("tracked outside artifact namespace\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True, timeout=10)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=FACTORY Test",
+                    "-c",
+                    "user.email=factory@example.invalid",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "ready rename fixture",
+                ],
+                cwd=root,
+                check=True,
+                timeout=10,
+            )
+            subprocess.run(
+                ["git", "mv", "--", source, destination],
+                cwd=root,
+                check=True,
+                timeout=10,
+            )
+
+            state = probe_repository(root)
+            self.assertTrue(state.known, state.error)
+            self.assertIn(source, state.dirty_paths)
+            self.assertIn(destination, state.dirty_paths)
+            self.assertEqual((source,), disallowed_dirty_paths(state, ("factory/artifacts/",)))
+
+            with patch("factory.daily_run.github_actions_enabled", return_value=False):
+                outcome = execute_daily_run(root, owner_id="rename-probe", run_date=RUN_DATE)
+            self.assertEqual("BLOCKED", outcome.status)
+            self.assertEqual("", outcome.selected_task_id)
+            self.assertEqual("", outcome.plan_path)
+            report = (root / outcome.report_path).read_text(encoding="utf-8")
+            self.assertIn(source, report)
+
+
+class DurableRunHistoryTests(unittest.TestCase):
+    def test_same_date_owner_is_idempotent_other_owner_blocks_and_next_date_proceeds(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = claim_daily_run(root, RUN_DATE, "owner-a")
+            claim_path = root / "factory/artifacts/run-history/2026-08-11.json"
+            original = claim_path.read_bytes()
+            retry = claim_daily_run(root, RUN_DATE, "owner-a")
+            self.assertEqual(first, retry)
+            self.assertEqual(original, claim_path.read_bytes())
+            with self.assertRaisesRegex(RunHistoryError, "already claimed"):
+                claim_daily_run(root, RUN_DATE, "owner-b")
+            self.assertEqual(original, claim_path.read_bytes())
+            next_day = claim_daily_run(root, date(2026, 8, 12), "owner-b")
+        self.assertEqual("2026-08-12", next_day.date)
+
+    def test_malformed_history_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            claim_path = root / "factory/artifacts/run-history/2026-08-11.json"
+            claim_path.parent.mkdir(parents=True)
+            claim_path.write_text('{"date":"2026-08-11"}\n', encoding="utf-8")
+            with self.assertRaisesRegex(RunHistoryError, "malformed daily claim"):
+                load_daily_claim(claim_path, RUN_DATE)
+            with self.assertRaises(RunHistoryError):
+                claim_daily_run(root, RUN_DATE, "owner-a")
+            self.assertEqual('{"date":"2026-08-11"}\n', claim_path.read_text(encoding="utf-8"))
+
+    def test_separate_process_invocations_share_durable_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+
+            def invoke(owner_id: str) -> subprocess.CompletedProcess[str]:
+                return subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "factory.run_history",
+                        "--root",
+                        str(root),
+                        "--date",
+                        RUN_DATE.isoformat(),
+                        "--owner-id",
+                        owner_id,
+                    ],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+
+            first = invoke("process-a")
+            blocked = invoke("process-b")
+            retry = invoke("process-a")
+        self.assertEqual(0, first.returncode, first.stderr)
+        self.assertEqual(1, blocked.returncode, blocked.stderr)
+        self.assertEqual(0, retry.returncode, retry.stderr)
+
+    def test_claim_cli_rejects_output_namespace_override_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            rejected = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "factory.run_history",
+                    "--root",
+                    str(root),
+                    "--date",
+                    RUN_DATE.isoformat(),
+                    "--owner-id",
+                    "cli-output-injection",
+                    "--output-dir",
+                    "governance",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            self.assertEqual(2, rejected.returncode, rejected.stderr)
+            self.assertIn("unrecognized arguments: --output-dir", rejected.stderr)
+            self.assertFalse((root / "governance/run-history").exists())
+            self.assertFalse((root / "factory/artifacts/run-history").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_factory_freeze.py
+++ b/tests/test_factory_freeze.py
@@ -79,10 +79,46 @@ class FactoryFreezeTests(unittest.TestCase):
         )
         self.assertIn('cron: "0 7 * * *"', workflow)
         self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("actions: read", workflow)
         self.assertIn("contents: read", workflow)
+        self.assertNotIn("actions: write", workflow)
+        self.assertNotIn("contents: write", workflow)
         self.assertIn("python3 -m factory.daily_run --dry-run", workflow)
+        self.assertIn(
+            "group: daily-factory-control-plane-${{ github.repository_id }}-${{ github.ref }}",
+            workflow,
+        )
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn('ZoneInfo("Europe/Moscow")', workflow)
+        self.assertNotIn("restore-keys:", workflow)
+        restore = workflow.index("Restore exact immutable daily claim")
+        selection = workflow.index("Run deterministic FACTORY-001A control plane")
+        save = workflow.index("Save immutable daily claim as optional transport")
+        self.assertLess(restore, selection)
+        self.assertLess(selection, save)
+        self.assertNotIn("python3 -m factory.run_history", workflow)
+        self.assertIn("FACTORY_GITHUB_TOKEN: ${{ github.token }}", workflow)
+        self.assertIn('${{ github.run_id }}:${{ github.run_attempt }}', workflow)
         for forbidden in ("git commit", "git push", "gh pr", "OPENAI_API_KEY", "secrets."):
             self.assertNotIn(forbidden, workflow)
+
+    def test_all_workflow_actions_are_sha_pinned_and_checkout_drops_credentials(self) -> None:
+        workflows = tuple(sorted((ROOT / ".github/workflows").glob("*.yml")))
+        combined = "\n".join(path.read_text(encoding="utf-8") for path in workflows)
+        expected = {
+            "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+            "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+            "actions/cache/restore": "0057852bfaa89a56745cba8c7296529d2fc39830",
+            "actions/cache/save": "0057852bfaa89a56745cba8c7296529d2fc39830",
+        }
+        action_lines = [line.strip() for line in combined.splitlines() if "uses: actions/" in line]
+        self.assertTrue(action_lines)
+        for line in action_lines:
+            action, revision = line.split("uses: ", 1)[1].split("@", 1)
+            self.assertEqual(expected[action], revision)
+        checkout_count = combined.count(f"uses: actions/checkout@{expected['actions/checkout']}")
+        self.assertEqual(checkout_count, combined.count("persist-credentials: false"))
 
     def test_limits_and_authorities_are_fixed(self) -> None:
         config = load_daily_config(ROOT / "factory/daily_run.toml")

--- a/tests/test_factory_freeze.py
+++ b/tests/test_factory_freeze.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from factory.configuration import load_daily_config
+from factory.integrity import canonical_sha256, parse_manifest, verify_manifest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class FactoryFreezeTests(unittest.TestCase):
+    def test_v11_is_preserved_and_v12_changes_only_self_check_hash(self) -> None:
+        v11 = dict(parse_manifest(ROOT, "docs/FROZEN_CORE_V11.sha256"))
+        v12 = dict(parse_manifest(ROOT, "docs/FROZEN_CORE_V12.sha256"))
+        self.assertEqual(10, len(v11))
+        self.assertEqual(set(v11), set(v12))
+        changed = {path for path in v11 if v11[path] != v12[path]}
+        self.assertEqual({"scripts/self_check.py"}, changed)
+        self.assertNotEqual(v11["scripts/self_check.py"], canonical_sha256(ROOT / "scripts/self_check.py"))
+        self.assertEqual(v12["scripts/self_check.py"], canonical_sha256(ROOT / "scripts/self_check.py"))
+
+    def test_active_v12_and_pm_dec_007_manifests_pass(self) -> None:
+        config = load_daily_config(ROOT / "factory/daily_run.toml")
+        self.assertEqual(
+            (),
+            verify_manifest(ROOT, config.active_core_manifest, config.active_core_manifest_sha256),
+        )
+        self.assertEqual(
+            (),
+            verify_manifest(ROOT, config.pm_dec_007_manifest, config.pm_dec_007_manifest_sha256),
+        )
+        self.assertEqual("docs/FROZEN_CORE_V12.sha256", config.active_core_manifest)
+        self.assertEqual(
+            "docs/FROZEN_PM_DEC_007_HYBRID_V2.sha256",
+            config.pm_dec_007_manifest,
+        )
+
+    def test_pm_v1_is_historical_and_v2_changes_only_operational_checks(self) -> None:
+        v1 = dict(parse_manifest(ROOT, "docs/FROZEN_PM_DEC_007_HYBRID_V1.sha256"))
+        v2 = dict(parse_manifest(ROOT, "docs/FROZEN_PM_DEC_007_HYBRID_V2.sha256"))
+        self.assertEqual(9, len(v1))
+        self.assertEqual(set(v1), set(v2))
+        self.assertEqual(
+            {"scripts/check_pm_dec007_hybrid.py", "tests/test_pm_dec007_hybrid.py"},
+            {path for path in v1 if v1[path] != v2[path]},
+        )
+
+    def test_factory_has_no_forbidden_runtime_imports(self) -> None:
+        forbidden = {
+            "openai",
+            "codex",
+            "telethon",
+            "telegram",
+            "aiogram",
+            "bitget",
+            "requests",
+            "httpx",
+            "websocket",
+        }
+        findings: list[str] = []
+        for path in sorted((ROOT / "factory").glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = [alias.name.split(".", 1)[0] for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module.split(".", 1)[0]]
+                else:
+                    continue
+                findings.extend(f"{path.name}:{name}" for name in names if name in forbidden)
+        self.assertEqual([], findings)
+
+    def test_workflow_is_dry_run_only_at_0700_utc(self) -> None:
+        workflow = (ROOT / ".github/workflows/daily-factory-control-plane.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('cron: "0 7 * * *"', workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("python3 -m factory.daily_run --dry-run", workflow)
+        for forbidden in ("git commit", "git push", "gh pr", "OPENAI_API_KEY", "secrets."):
+            self.assertNotIn(forbidden, workflow)
+
+    def test_limits_and_authorities_are_fixed(self) -> None:
+        config = load_daily_config(ROOT / "factory/daily_run.toml")
+        self.assertEqual((1, 1, 2, 90), (
+            config.max_tasks_per_day,
+            config.max_parallel_writers,
+            config.max_correction_loops,
+            config.max_run_time_minutes,
+        ))
+        self.assertFalse(config.auto_merge)
+        self.assertFalse(config.auto_product_approval)
+        self.assertFalse(config.paper_authority)
+        self.assertFalse(config.live_authority)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factory_github_history.py
+++ b/tests/test_factory_github_history.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.configuration import ConfigurationError
+from factory.daily_run import execute_daily_run
+from factory.github_history import (
+    API_VERSION,
+    MAX_PAGES,
+    PER_PAGE,
+    TIMEOUT_SECONDS,
+    USER_AGENT,
+    WORKFLOW_FILE,
+    WORKFLOW_PATH,
+    GitHubHistoryError,
+    _GitHubContext,
+    _load_github_context,
+    _verify_github_daily_history_for_test,
+    verify_github_daily_history,
+)
+
+
+RUN_DATE = date(2026, 8, 11)
+WORKFLOW_ID = 4242
+CONTEXT = _GitHubContext(
+    token="test-token-never-log",
+    repository="owner/repository",
+    run_id=100,
+    run_attempt=1,
+    ref="refs/heads/main",
+    branch="main",
+    workflow_path=WORKFLOW_PATH,
+    api_url="https://api.github.com",
+)
+_MISSING = object()
+
+
+def workflow_metadata(
+    *,
+    workflow_id: object = WORKFLOW_ID,
+    path: object = WORKFLOW_PATH,
+    state: object = "active",
+) -> dict[str, object]:
+    return {
+        "id": workflow_id,
+        "node_id": "W_kwDO-test",
+        "name": "daily-factory-control-plane",
+        "path": path,
+        "state": state,
+    }
+
+
+def workflow_run(
+    run_id: int,
+    *,
+    workflow_id: object = WORKFLOW_ID,
+    event: object = "workflow_dispatch",
+    status: object = "completed",
+    conclusion: object = "success",
+    started: object = "2026-08-11T07:00:00Z",
+    repository: object = "owner/repository",
+    branch: object = "main",
+    run_attempt: object = 1,
+    path: object = _MISSING,
+) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": run_id,
+        "workflow_id": workflow_id,
+        "run_attempt": run_attempt,
+        "event": event,
+        "status": status,
+        "conclusion": conclusion,
+        "run_started_at": started,
+        "repository": {"full_name": repository},
+        "head_branch": branch,
+    }
+    if path is not _MISSING:
+        value["path"] = path
+    return value
+
+
+class FakeTransport:
+    def __init__(
+        self,
+        runs: list[dict[str, object]] | None = None,
+        *,
+        metadata: dict[str, object] | None = None,
+        pages: dict[int, list[dict[str, object]]] | None = None,
+        total_count: int | None = None,
+        metadata_status: int = 200,
+        runs_status: int = 200,
+        metadata_body: bytes | None = None,
+        runs_body: bytes | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.metadata = metadata if metadata is not None else workflow_metadata()
+        self.pages = pages if pages is not None else {1: list(runs or [])}
+        self.total_count = (
+            total_count
+            if total_count is not None
+            else sum(len(items) for items in self.pages.values())
+        )
+        self.metadata_status = metadata_status
+        self.runs_status = runs_status
+        self.metadata_body = metadata_body
+        self.runs_body = runs_body
+        self.error = error
+        self.calls: list[tuple[str, dict[str, str], float]] = []
+
+    def __call__(
+        self, url: str, headers: dict[str, str], timeout: float
+    ) -> tuple[int, bytes]:
+        self.calls.append((url, headers, timeout))
+        if self.error is not None:
+            raise self.error
+        if "/runs?" not in url:
+            body = self.metadata_body
+            if body is None:
+                body = json.dumps(self.metadata).encode("utf-8")
+            return self.metadata_status, body
+        body = self.runs_body
+        if body is None:
+            page = int(url.rsplit("page=", 1)[1])
+            body = json.dumps(
+                {
+                    "total_count": self.total_count,
+                    "workflow_runs": self.pages.get(page, []),
+                }
+            ).encode("utf-8")
+        return self.runs_status, body
+
+
+def verify_with(
+    runs: list[dict[str, object]],
+    *,
+    context: _GitHubContext = CONTEXT,
+    transport: FakeTransport | None = None,
+):
+    effective_transport = transport or FakeTransport(runs)
+    witness = _verify_github_daily_history_for_test(
+        context, RUN_DATE, transport=effective_transport
+    )
+    return witness, effective_transport
+
+
+def trusted_environment(**overrides: str) -> dict[str, str]:
+    value = {
+        "GITHUB_ACTIONS": "true",
+        "FACTORY_GITHUB_TOKEN": CONTEXT.token,
+        "GITHUB_REPOSITORY": CONTEXT.repository,
+        "GITHUB_RUN_ID": str(CONTEXT.run_id),
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_REF": CONTEXT.ref,
+        "GITHUB_REF_NAME": CONTEXT.branch,
+        "GITHUB_REF_TYPE": "branch",
+        "GITHUB_WORKFLOW_REF": (
+            f"{CONTEXT.repository}/{WORKFLOW_PATH}@{CONTEXT.ref}"
+        ),
+        "GITHUB_API_URL": CONTEXT.api_url,
+    }
+    value.update(overrides)
+    return value
+
+
+class GitHubHistoryWitnessTests(unittest.TestCase):
+    def test_metadata_resolves_canonical_numeric_identity_then_runs_query_uses_only_id(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        witness, transport = verify_with([current])
+        self.assertEqual((100, WORKFLOW_ID, 1), (
+            witness.current_run_id,
+            witness.workflow_id,
+            witness.checked_runs,
+        ))
+        self.assertEqual(2, len(transport.calls))
+        metadata_url, headers, timeout = transport.calls[0]
+        runs_url = transport.calls[1][0]
+        self.assertEqual(
+            f"https://api.github.com/repos/owner/repository/actions/workflows/{WORKFLOW_FILE}",
+            metadata_url,
+        )
+        self.assertIn(f"/actions/workflows/{WORKFLOW_ID}/runs?", runs_url)
+        self.assertNotIn(f"/actions/workflows/{WORKFLOW_FILE}/runs", runs_url)
+        self.assertIn("branch=main", runs_url)
+        self.assertIn("per_page=100", runs_url)
+        self.assertNotIn(CONTEXT.token, metadata_url + runs_url)
+        self.assertEqual("application/vnd.github+json", headers["Accept"])
+        self.assertEqual(f"Bearer {CONTEXT.token}", headers["Authorization"])
+        self.assertEqual(API_VERSION, headers["X-GitHub-Api-Version"])
+        self.assertEqual(USER_AGENT, headers["User-Agent"])
+        self.assertEqual(TIMEOUT_SECONDS, timeout)
+
+    def test_metadata_failures_are_closed(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        cases = {
+            "non_200": FakeTransport([current], metadata_status=404),
+            "non_object": FakeTransport([current], metadata_body=b"[]"),
+            "bool_id": FakeTransport([current], metadata=workflow_metadata(workflow_id=True)),
+            "zero_id": FakeTransport([current], metadata=workflow_metadata(workflow_id=0)),
+            "path_mismatch": FakeTransport(
+                [current], metadata=workflow_metadata(path=".github/workflows/other.yml")
+            ),
+            "disabled": FakeTransport(
+                [current], metadata=workflow_metadata(state="disabled_manually")
+            ),
+            "duplicate_key": FakeTransport(
+                [current],
+                metadata_body=(
+                    b'{"id":4242,"id":4243,"path":".github/workflows/'
+                    b'daily-factory-control-plane.yml","state":"active"}'
+                ),
+            ),
+        }
+        for name, transport in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(GitHubHistoryError):
+                    verify_with([current], transport=transport)
+
+    def test_candidate_workflow_id_repository_and_branch_contradictions_fail_closed(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        cases = (
+            workflow_run(99, workflow_id=WORKFLOW_ID + 1),
+            workflow_run(99, repository="other/repository"),
+            workflow_run(99, branch="attacker"),
+        )
+        for candidate in cases:
+            with self.subTest(candidate=candidate):
+                with self.assertRaisesRegex(GitHubHistoryError, "contradicts"):
+                    verify_with([current, candidate])
+
+    def test_candidate_path_has_zero_authority_for_current_and_consuming_prior(self) -> None:
+        representations = (
+            ".github/workflows/daily-factory-control-plane.yml@refs/heads/attacker",
+            ".github/workflows/daily-factory-control-plane.yml@attacker",
+            ".github/workflows/daily-factory-control-plane.yml@main",
+            _MISSING,
+            12345,
+        )
+        for path in representations:
+            with self.subTest(path=path):
+                current = workflow_run(
+                    100, status="in_progress", conclusion=None, path=path
+                )
+                witness, _ = verify_with([current])
+                self.assertEqual(WORKFLOW_ID, witness.workflow_id)
+                prior = workflow_run(99, event="schedule", path=path)
+                with self.assertRaisesRegex(GitHubHistoryError, "already consumed"):
+                    verify_with([current, prior])
+
+    def test_branch_refs_are_strict_and_feature_branch_uses_encoded_short_name(self) -> None:
+        invalid = {
+            "tag": trusted_environment(
+                GITHUB_REF="refs/tags/v1",
+                GITHUB_REF_NAME="v1",
+                GITHUB_REF_TYPE="tag",
+                GITHUB_WORKFLOW_REF=f"{CONTEXT.repository}/{WORKFLOW_PATH}@refs/tags/v1",
+            ),
+            "pull": trusted_environment(
+                GITHUB_REF="refs/pull/12/merge",
+                GITHUB_REF_NAME="12/merge",
+                GITHUB_WORKFLOW_REF=(
+                    f"{CONTEXT.repository}/{WORKFLOW_PATH}@refs/pull/12/merge"
+                ),
+            ),
+            "malformed": trusted_environment(
+                GITHUB_REF="refs/heads/feature//unsafe",
+                GITHUB_REF_NAME="feature//unsafe",
+                GITHUB_WORKFLOW_REF=(
+                    f"{CONTEXT.repository}/{WORKFLOW_PATH}@refs/heads/feature//unsafe"
+                ),
+            ),
+            "name_contradiction": trusted_environment(GITHUB_REF_NAME="attacker"),
+            "type_contradiction": trusted_environment(GITHUB_REF_TYPE="tag"),
+        }
+        for name, environment in invalid.items():
+            with self.subTest(name=name), patch.dict(os.environ, environment, clear=True):
+                with self.assertRaises(GitHubHistoryError):
+                    _load_github_context()
+
+        feature = "feature/factory-witness"
+        feature_context = replace(
+            CONTEXT,
+            ref=f"refs/heads/{feature}",
+            branch=feature,
+        )
+        current = workflow_run(
+            100, status="in_progress", conclusion=None, branch=feature
+        )
+        witness, transport = verify_with([current], context=feature_context)
+        self.assertEqual(WORKFLOW_ID, witness.workflow_id)
+        self.assertIn("branch=feature%2Ffactory-witness", transport.calls[1][0])
+
+    def test_trusted_workflow_ref_is_exactly_cross_checked(self) -> None:
+        cases = {
+            "missing": None,
+            "empty": "",
+            "foreign_repository": (
+                f"attacker/repository/{WORKFLOW_PATH}@{CONTEXT.ref}"
+            ),
+            "foreign_workflow": (
+                f"{CONTEXT.repository}/.github/workflows/other.yml@{CONTEXT.ref}"
+            ),
+            "foreign_ref": (
+                f"{CONTEXT.repository}/{WORKFLOW_PATH}@refs/heads/attacker"
+            ),
+            "short_ref": f"{CONTEXT.repository}/{WORKFLOW_PATH}@main",
+            "unsuffixed": f"{CONTEXT.repository}/{WORKFLOW_PATH}",
+            "similar_path": (
+                f"{CONTEXT.repository}/{WORKFLOW_PATH}.evil@{CONTEXT.ref}"
+            ),
+            "duplicate_at": (
+                f"{CONTEXT.repository}/{WORKFLOW_PATH}@@{CONTEXT.ref}"
+            ),
+        }
+        for name, workflow_ref in cases.items():
+            with self.subTest(name=name):
+                environment = trusted_environment()
+                if workflow_ref is None:
+                    del environment["GITHUB_WORKFLOW_REF"]
+                else:
+                    environment["GITHUB_WORKFLOW_REF"] = workflow_ref
+                with patch.dict(os.environ, environment, clear=True):
+                    with self.assertRaises(GitHubHistoryError):
+                        _load_github_context()
+
+    def test_no_prior_is_available_and_all_started_production_outcomes_consume(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        witness, _ = verify_with([current])
+        self.assertEqual(1, witness.checked_runs)
+        cases = (
+            ("schedule", "completed", "success"),
+            ("workflow_dispatch", "completed", "failure"),
+            ("schedule", "completed", "cancelled"),
+            ("workflow_dispatch", "in_progress", None),
+        )
+        for event, status, conclusion in cases:
+            with self.subTest(event=event, status=status, conclusion=conclusion):
+                prior = workflow_run(
+                    99, event=event, status=status, conclusion=conclusion
+                )
+                with self.assertRaisesRegex(GitHubHistoryError, "already consumed"):
+                    verify_with([current, prior])
+
+    def test_schedule_and_manual_history_block_each_other(self) -> None:
+        for current_event, prior_event in (
+            ("workflow_dispatch", "schedule"),
+            ("schedule", "workflow_dispatch"),
+        ):
+            with self.subTest(current=current_event, prior=prior_event):
+                current = workflow_run(
+                    100,
+                    event=current_event,
+                    status="in_progress",
+                    conclusion=None,
+                )
+                prior = workflow_run(99, event=prior_event)
+                with self.assertRaisesRegex(GitHubHistoryError, "already consumed"):
+                    verify_with([current, prior])
+
+    def test_previous_moscow_date_and_nonproduction_event_do_not_consume(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        previous = workflow_run(99, started="2026-08-10T07:00:00Z")
+        push = workflow_run(98, event="push")
+        witness, _ = verify_with([current, previous, push])
+        self.assertEqual(3, witness.checked_runs)
+
+    def test_rerun_attempt_denies_before_metadata_or_history_api(self) -> None:
+        transport = FakeTransport([workflow_run(100)])
+        with self.assertRaisesRegex(GitHubHistoryError, "rerun attempt"):
+            _verify_github_daily_history_for_test(
+                replace(CONTEXT, run_attempt=2),
+                RUN_DATE,
+                transport=transport,
+            )
+        self.assertEqual([], transport.calls)
+
+    def test_malformed_run_attempt_environment_fails_closed(self) -> None:
+        for attempt in ("", "0", "01", "-1", "true", "two"):
+            with self.subTest(attempt=attempt), patch.dict(
+                os.environ,
+                trusted_environment(GITHUB_RUN_ATTEMPT=attempt),
+                clear=True,
+            ):
+                with self.assertRaises(GitHubHistoryError):
+                    _load_github_context()
+
+    def test_current_run_is_fully_witnessed_before_exact_id_exclusion(self) -> None:
+        cases = {
+            "absent": [workflow_run(99, started="2026-08-10T07:00:00Z")],
+            "attempt": [workflow_run(100, run_attempt=2)],
+            "event": [workflow_run(100, event="push")],
+            "date": [workflow_run(100, started="2026-08-10T07:00:00Z")],
+        }
+        for name, runs in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    GitHubHistoryError, "current GitHub workflow run"
+                ):
+                    verify_with(runs)
+
+    def test_api_unavailable_non_200_and_malformed_responses_fail_closed(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        cases = {
+            "unavailable": FakeTransport(error=TimeoutError("hidden")),
+            "runs_non_200": FakeTransport([current], runs_status=503),
+            "runs_non_object": FakeTransport([current], runs_body=b"[]"),
+            "runs_missing": FakeTransport([current], runs_body=b'{"total_count":1}'),
+            "bool_workflow_id": FakeTransport(
+                [workflow_run(100, workflow_id=True)]
+            ),
+            "bad_timestamp": FakeTransport(
+                [workflow_run(100, started="2026-08-11 07:00:00")]
+            ),
+        }
+        for name, transport in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaises(GitHubHistoryError):
+                    verify_with([current], transport=transport)
+
+    def test_exhaustive_pagination_cannot_hide_consuming_run(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        harmless = [
+            workflow_run(1000 + index, event="push", started="2026-08-10T07:00:00Z")
+            for index in range(PER_PAGE - 1)
+        ]
+        consuming = workflow_run(9999, event="schedule")
+        transport = FakeTransport(
+            pages={1: [current, *harmless], 2: [consuming]},
+            total_count=PER_PAGE + 1,
+        )
+        with self.assertRaisesRegex(GitHubHistoryError, "already consumed"):
+            verify_with([], transport=transport)
+        self.assertEqual(3, len(transport.calls))
+
+    def test_incomplete_or_changing_pagination_fails_closed(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        first_page = [current] + [
+            workflow_run(1000 + index, event="push", started="2026-08-10T07:00:00Z")
+            for index in range(PER_PAGE - 1)
+        ]
+        truncated = FakeTransport(
+            pages={1: first_page, 2: []},
+            total_count=PER_PAGE + 1,
+        )
+        with self.assertRaisesRegex(GitHubHistoryError, "truncated"):
+            verify_with([], transport=truncated)
+
+        over_limit_pages = {
+            page: [
+                workflow_run(
+                    page * 10000 + index,
+                    event="push",
+                    started="2026-08-10T07:00:00Z",
+                )
+                for index in range(PER_PAGE)
+            ]
+            for page in range(1, MAX_PAGES + 1)
+        }
+        over_limit_pages[1][0] = current
+        too_many = FakeTransport(
+            pages=over_limit_pages,
+            total_count=MAX_PAGES * PER_PAGE + 1,
+        )
+        with self.assertRaisesRegex(GitHubHistoryError, "truncated"):
+            verify_with([], transport=too_many)
+
+    def test_public_witness_uses_environment_and_real_transport_boundary_only(self) -> None:
+        current = workflow_run(100, status="in_progress", conclusion=None)
+        transport = FakeTransport([current])
+        with (
+            patch.dict(os.environ, trusted_environment(), clear=True),
+            patch("factory.github_history._github_transport", side_effect=transport),
+        ):
+            witness = verify_github_daily_history(RUN_DATE)
+            with self.assertRaises(TypeError):
+                verify_github_daily_history(RUN_DATE, context=CONTEXT)
+        self.assertEqual(WORKFLOW_ID, witness.workflow_id)
+
+    def test_production_witness_precedes_claim_and_failure_stops_before_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            events: list[str] = []
+
+            def witness(_run_date: date) -> None:
+                events.append("witness")
+
+            def claim(*_args, **_kwargs) -> None:
+                events.append("claim")
+
+            with (
+                patch("factory.daily_run.load_daily_config", return_value=object()),
+                patch("factory.daily_run.load_registry", return_value=object()),
+                patch("factory.daily_run.github_actions_enabled", return_value=True),
+                patch("factory.daily_run.verify_github_daily_history", side_effect=witness),
+                patch("factory.daily_run.claim_daily_run", side_effect=claim),
+                patch("factory.daily_run.probe_repository", return_value=object()),
+                patch("factory.daily_run.verify_integrity", return_value=()),
+                patch(
+                    "factory.daily_run._execute_daily_run_core",
+                    side_effect=ConfigurationError("stop after ordering evidence"),
+                ),
+            ):
+                with self.assertRaises(ConfigurationError):
+                    execute_daily_run(root, owner_id="100:1", run_date=RUN_DATE)
+            self.assertEqual(["witness", "claim"], events)
+
+            with (
+                patch("factory.daily_run.load_daily_config", return_value=object()),
+                patch("factory.daily_run.load_registry", return_value=object()),
+                patch("factory.daily_run.github_actions_enabled", return_value=True),
+                patch(
+                    "factory.daily_run.verify_github_daily_history",
+                    side_effect=GitHubHistoryError("API unavailable"),
+                ),
+                patch("factory.daily_run.claim_daily_run") as local_claim,
+            ):
+                with self.assertRaises(GitHubHistoryError):
+                    execute_daily_run(root, owner_id="100:1", run_date=RUN_DATE)
+            local_claim.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add FACTORY-001A deterministic daily development control plane
- add factory registry/state/config and owner-facing factory documentation
- add dry-run daily scheduler/control-plane workflow
- add focused factory tests and integrity checks

## Scope

This PR is intentionally limited to FACTORY-001A and is based on `feature/offline-mvp-v0.21`.

It does **not** start FACTORY-001B, autonomous AI execution, Paper, Limited Live, Live, real trading, credentials, exchange execution, or financial authority.

## Safety

- deterministic / dry-run control plane only
- no automatic merge
- no automatic product approval
- no Paper authority
- no Live authority
- one bounded factory control-plane step only

## Validation target

Authoritative Ubuntu GitHub Actions quality gates must pass before Foundation Seal.
